### PR TITLE
Feat/kakao social login

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,9 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.0.4'
 
 	// security
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
-//	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-//	testImplementation 'org.springframework.security:spring-security-test'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	testImplementation 'org.springframework.security:spring-security-test'
 
 	// DB
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'  // JDBC API

--- a/src/main/java/com/doLink_server/DoLinkApplication.java
+++ b/src/main/java/com/doLink_server/DoLinkApplication.java
@@ -2,8 +2,10 @@ package com.doLink_server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing // JPA Auditing 활성화 (엔티티의 생성/수정 시간 자동 관리)
 public class DoLinkApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/doLink_server/auth/controller/AuthController.java
+++ b/src/main/java/com/doLink_server/auth/controller/AuthController.java
@@ -1,0 +1,65 @@
+package com.doLink_server.auth.controller;
+
+import com.doLink_server.auth.service.JwtIssueService;
+import com.doLink_server.auth.service.RedisService;
+import com.doLink_server.global.common.ApiResponse;
+import com.doLink_server.global.common.status.ErrorStatus;
+import com.doLink_server.security.exception.CustomAuthenticationException;
+import com.doLink_server.security.jwt.JwtProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 인증 관련 컨트롤러
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/auth")
+@Tag(name = "Auth", description = "인증 관련 API")
+public class AuthController {
+
+    private final JwtProvider jwtProvider;
+    private final JwtIssueService jwtIssueService;
+    private final RedisService redisService;
+
+    /**
+     * AccessToken 재발급
+     * @param request http only Cookie 리프레시 토큰 객체
+     * @return 액세스 토큰
+     */
+    @PostMapping("/reissue")
+    @Operation(summary = "AccessToken 재발급 요청", description = "만료된 AccessToken 재발급을 요청한다.")
+    public ResponseEntity<ApiResponse<String>> issueAccessToken(
+            @Parameter(hidden = true) HttpServletRequest request
+    ) {
+        // ✅ Refresh Token 유효성 및 Redis 토큰 일치 확인
+        Cookie[] cookies = request.getCookies();
+        String refreshToken = jwtIssueService.getRefreshTokenFromCookie(cookies);
+        jwtIssueService.validateToken(refreshToken, "refresh");
+
+        String userId = jwtProvider.getUserId(refreshToken);
+        if (redisService.isInvalidRefreshToken(userId, refreshToken)) {
+            log.error("Redis에 저장된 RefreshToken과 불일치");
+            throw new CustomAuthenticationException(ErrorStatus.TOKEN_INVALIDATE_ERROR);
+        }
+
+        String newAccessToken = jwtIssueService.reIssueAccessToken(refreshToken);
+        ApiResponse<String> response = ApiResponse.onSuccess(newAccessToken);
+        return ResponseEntity.ok()
+                .header("Authorization", "Bearer " + newAccessToken)
+                .body(response);
+    }
+
+
+
+}

--- a/src/main/java/com/doLink_server/auth/oauth/handler/CustomOAuth2ExceptionHandler.java
+++ b/src/main/java/com/doLink_server/auth/oauth/handler/CustomOAuth2ExceptionHandler.java
@@ -1,0 +1,23 @@
+package com.doLink_server.auth.oauth.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * OAuth2 인증 실패시 처리 핸들러
+ */
+@Component
+public class CustomOAuth2ExceptionHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+        // 여기에 로그인 실패 후 처리할 내용을 작성하기!
+        response.sendRedirect("/login-failure");
+    }
+}

--- a/src/main/java/com/doLink_server/auth/oauth/handler/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/doLink_server/auth/oauth/handler/CustomOAuth2SuccessHandler.java
@@ -1,0 +1,202 @@
+package com.doLink_server.auth.oauth.handler;
+
+
+import com.doLink_server.auth.service.JwtIssueService;
+import com.doLink_server.auth.service.RedisService;
+import com.doLink_server.global.util.UUIDToBytesUtil;
+import com.doLink_server.security.jwt.JwtProperties;
+import com.doLink_server.security.jwt.JwtProvider;
+import com.doLink_server.user.entity.Users;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * OAuth2 인증 성공시 처리 핸들러
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtProvider jwtProvider;
+    private final RedisService redisService;
+    private final JwtProperties jwtProperties;
+    private final JwtIssueService jwtIssueService;
+    private final Environment environment;
+
+    @Value("${auth.redirect.url}")
+    private String redirectUrl;
+
+    @Value("${auth.cookie.domain}")
+    private String cookieDomain;
+
+    /**
+     * 인증 성공시, 리프레시 토큰을 Http Only 쿠키로 반환한다.
+     * 클라이언트가 기존에 가지고 있던 토큰을 쿠키에서 직접 읽어 Redis에 저장된 토큰과 비교한다.
+     * 유효하지 않거나 만료된 경우 새로 발급하고 Redis에 저장 후 쿠키에 담아 응답한다.
+     */
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        Users user = (Users) oAuth2User.getAttributes().get("user");
+        String userId = UUIDToBytesUtil.convertToEntityAttribute(user.getUserId()).toString();
+
+        // 1. 인증 객체에서 SocialId 추출
+        String SocialId = extractSocialId(authentication, response);
+        if (SocialId == null) {
+            log.warn("▶ SocialId를 추출하지 못해 인증 성공 처리 중단");
+            return;
+        }
+
+        // 2. 클라이언트가 가진 refreshToken 쿠키에서 읽기
+        String clientRefreshToken = extractRefreshTokenFromCookie(request);
+        if (clientRefreshToken == null) {
+            log.info("▶ 클라이언트 refreshToken 없음");
+        }
+
+        // 3. Redis에 저장된 refreshToken 조회
+        String redisRefreshToken = redisService.getRefreshToken(userId);
+        if (redisRefreshToken == null) {
+            log.info("▶ Redis에 refreshToken 없음");
+        }
+
+        // 4. 토큰 검증 로직
+        String finalRefreshToken;
+        if (clientRefreshToken == null || redisRefreshToken == null) {
+            // 토큰 중 하나라도 없으면 새 토큰 발급
+            finalRefreshToken = jwtIssueService.issueRefreshToken(userId);
+            redisService.saveRefreshToken(userId, finalRefreshToken);
+            log.info("▶ 새 refreshToken 발급 및 Redis에 저장 : {}", finalRefreshToken);
+        } else if (!redisRefreshToken.equals(clientRefreshToken)) {
+            // 토큰 불일치
+            log.info("▶ Redis 토큰과 클라이언트 토큰 불일치");
+            logTokenDetails("Redis 저장 토큰", redisRefreshToken);
+            logTokenDetails("클라이언트 토큰", clientRefreshToken);
+            finalRefreshToken = jwtIssueService.issueRefreshToken(userId);
+        } else {
+            // 토큰 일치 -> 유효성 검사
+            boolean isValid = jwtProvider.validateToken(clientRefreshToken);
+            log.info("▶ JWT 유효성 검사 결과: {}", isValid);
+            if (isValid) {
+                finalRefreshToken = clientRefreshToken;
+                log.info("▶ 기존 refreshToken 유효 — 재사용");
+            } else {
+                log.info("▶ 토큰 유효하지 않음, 새 토큰 발급");
+                finalRefreshToken = jwtIssueService.issueRefreshToken(userId);
+            }
+        }
+
+        // 5. HttpOnly, Secure 옵션 적용한 쿠키에 refreshToken 세팅
+        // accessToken은 쿠키에 담지 않고, 필요하다면 이후 API 요청으로 전달받도록 구성
+        addRefreshTokenCookie(response, finalRefreshToken);
+
+//        String accessToken = tokenService.issueAccessToken(userId);
+//        response.setHeader("Authorization", "Bearer " + accessToken);
+//        response.setContentType("application/json; charset=UTF-8");
+//        response.setCharacterEncoding("UTF-8");
+//
+//        // 공통 응답 포맷으로 JSON 반환
+//        Map<String, String> tokenInfo = new HashMap<>();
+//        tokenInfo.put("accessToken", accessToken);
+//
+//        // 6. 로그인 성공 응답 (JSON)
+//        ApiResponse<Map<String, String>> apiResponse = ApiResponse.onSuccess(tokenInfo);
+//        objectMapper.writeValue(response.getWriter(), apiResponse);
+
+        response.sendRedirect(redirectUrl);
+
+        log.info("▶ OAuth2 인증 성공 후 리다이렉트: {}", redirectUrl);
+
+    }
+
+
+    /**
+     * 인증 객체에서 SocialId를 추출하는 메서드
+     */
+    private String extractSocialId(Authentication authentication, HttpServletResponse response) throws IOException {
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof DefaultOAuth2User defaultUser) {
+            Object idAttr = defaultUser.getAttribute("id");
+            if (idAttr != null) {
+                return idAttr.toString();
+            } else {
+                logAndSendError(response, "DefaultOAuth2User에 id 속성이 없습니다.");
+            }
+        } else {
+            logAndSendError(response, "지원하지 않는 principal 타입: " + principal.getClass());
+        }
+        return null;
+    }
+
+    /**
+     * 요청 쿠키에서 refreshToken 값을 추출한다.
+     * @param request HttpServletRequest
+     * @return 쿠키에 "refresh" 이름으로 저장된 토큰 값, 없으면 null 반환
+     */
+    private String extractRefreshTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() == null) return null;
+
+        for (Cookie cookie : request.getCookies()) {
+            if ("refresh".equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * HttpOnly, Secure 옵션이 적용된 리프레시 토큰 쿠키를 생성하고 응답에 추가
+     */
+    private void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        Cookie cookie = new Cookie("refresh", refreshToken);
+        cookie.setHttpOnly(true);  // 자바스크립트에서 접근 불가
+        cookie.setSecure(isSecure());  // 환경에 따라 true/false
+        cookie.setPath("/");       // 모든 경로에 대해 유효
+        cookie.setDomain(cookieDomain); // 루트 도메인
+        cookie.setMaxAge((int) (jwtProperties.getRefreshTokenExpiration() / 1000));  // 초 단위 만료시간
+        response.addCookie(cookie);
+    }
+
+    private boolean isSecure() {
+        for (String profile : environment.getActiveProfiles()) {
+            if ("prod".equals(profile)) {
+                return true;
+            }
+        }
+        return false; // local, dev 등의 경우
+    }
+
+    /**
+     * 오류 로그를 기록하고 401 Unauthorized 응답 전송
+     */
+    private void logAndSendError(HttpServletResponse response, String message) throws IOException {
+        log.error(message);
+
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, message);
+    }
+
+    /**
+     * JWT 토큰의 Claims(payload)를 JSON 형식으로 예쁘게 로그에 출력한다.
+     * 디버깅용으로 Redis와 클라이언트 토큰 비교 시 호출하면 유용하다.
+     */
+    private void logTokenDetails(String label, String token) {
+        jwtProvider.extractClaimsAsJson(token).ifPresentOrElse(
+                json -> log.info(">>> JWT Claims [{}]:\n{}", label, json),
+                () -> log.warn("JWT Claims [{}]: 유효하지 않아 파싱 실패", label)
+        );
+    }
+}

--- a/src/main/java/com/doLink_server/auth/oauth/model/CustomOAuth2UserDetails.java
+++ b/src/main/java/com/doLink_server/auth/oauth/model/CustomOAuth2UserDetails.java
@@ -1,0 +1,63 @@
+package com.doLink_server.auth.oauth.model;
+
+
+import com.doLink_server.security.dto.UserDTO;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * 스프링 시큐리티 인증용 UserDetails 구현체
+ */
+@Getter
+public class CustomOAuth2UserDetails implements UserDetails {
+
+    private final String userId;
+
+    /**
+     * 생성자
+     * @param userDTO 인증 시 사용자 식별 정보 전달용 DTO
+     */
+    public CustomOAuth2UserDetails(UserDTO userDTO) {
+        this.userId = userDTO.getUserId();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        // ROLE_USER 권한 고정으로 줌. 필요하면 확장 가능
+        return Collections.singleton(() -> "ROLE_USER");
+    }
+
+    @Override
+    public String getPassword() {
+        return null; // JWT 인증에서는 비밀번호 사용 안 함
+    }
+
+    @Override
+    public String getUsername() {
+        return userId;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true; // 필요하면 변경 가능
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true; // 필요하면 변경 가능
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true; // 필요하면 변경 가능
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true; // 필요하면 변경 가능
+    }
+}

--- a/src/main/java/com/doLink_server/auth/oauth/model/KakaoUserInfo.java
+++ b/src/main/java/com/doLink_server/auth/oauth/model/KakaoUserInfo.java
@@ -1,0 +1,59 @@
+package com.doLink_server.auth.oauth.model;
+
+import java.util.Map;
+
+/**
+ * 카카오 사용자 정보 DTO
+ */
+public class KakaoUserInfo implements OAuth2UserInfo {
+
+    private final Map<String, Object> attributes;
+
+    public KakaoUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getProvider() {
+        return "kakao";
+    }
+
+    @Override
+    public String getProviderId() {
+        // attributes.get("id")는 Long 또는 Integer일 수 있으므로 toString()
+        Object id = attributes.get("id");
+        return id != null ? id.toString() : null;
+    }
+
+    @Override
+    public String getEmail() {
+        Map<String, Object> kakaoAccount = getMap(attributes, "kakao_account");
+        return kakaoAccount != null ? (String) kakaoAccount.get("email") : null;
+    }
+
+    @Override
+    public String getNickname() {
+        Map<String, Object> profile = getProfile();
+        return profile != null ? (String) profile.get("nickname") : null;
+    }
+
+    public String getProfileImageUrl() {
+        Map<String, Object> profile = getProfile();
+        return profile != null ? (String) profile.get("profile_image_url") : null;
+    }
+
+    private Map<String, Object> getProfile() {
+        Map<String, Object> kakaoAccount = getMap(attributes, "kakao_account");
+        return kakaoAccount != null ? getMap(kakaoAccount, "profile") : null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> getMap(Map<String, Object> source, String key) {
+        Object value = source.get(key);
+        if (value instanceof Map) {
+            return (Map<String, Object>) value;
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/doLink_server/auth/oauth/model/OAuth2UserInfo.java
+++ b/src/main/java/com/doLink_server/auth/oauth/model/OAuth2UserInfo.java
@@ -1,0 +1,18 @@
+package com.doLink_server.auth.oauth.model;
+
+/**
+ * 소셜 제공자의 사용자 정보를 공통화하기 위한 인터페이스
+ * 각 제공자별 구현체(GoogleUserInfo, KakaoUserInfo 등)가 이걸 구현함
+ */
+public interface OAuth2UserInfo {
+    //제공자 (Ex. naver, google, ...)
+    String getProvider();
+    //제공자에서 발급해주는 아이디(번호)
+    String getProviderId();
+    //이메일
+    String getEmail();
+    //사용자 실명 (설정한 이름)
+    String getNickname();
+    //사용자 프로필 사진
+    String getProfileImageUrl();
+}

--- a/src/main/java/com/doLink_server/auth/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/doLink_server/auth/oauth/service/CustomOAuth2UserService.java
@@ -1,0 +1,105 @@
+package com.doLink_server.auth.oauth.service;
+
+
+import com.doLink_server.auth.oauth.model.KakaoUserInfo;
+import com.doLink_server.auth.oauth.model.OAuth2UserInfo;
+import com.doLink_server.global.exception.GeneralException;
+import com.doLink_server.user.entity.Users;
+import com.doLink_server.user.service.UserService;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * OAuth2 로그인 성공 후 추가 처리를 위한 커스텀 구현체
+ */
+@Service
+@Slf4j
+@AllArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserService userService;
+
+    /**
+     * OAuth2 로그인 성공 시 호출되는 메서드
+     */
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        Map<String, Object> attributes = logAttributes(oAuth2User.getAttributes());
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String userNameAttributeName = extractSocialAttributeName(userRequest);
+
+        OAuth2UserInfo userInfo = createOAuth2UserInfo(registrationId, attributes);
+        Users user = findOrRegisterUser(userInfo);
+
+        Map<String, Object> extendedAttributes = buildExtendedAttributes(attributes, user);
+        List<GrantedAuthority> authorities = AuthorityUtils.createAuthorityList("ROLE_USER");
+
+        return new DefaultOAuth2User(authorities, extendedAttributes, userNameAttributeName);
+    }
+
+    /**
+     * 제공자별 유저 정보 파싱을 위한 DTO 생성
+     */
+    private OAuth2UserInfo createOAuth2UserInfo(String registrationId, Map<String, Object> attributes) {
+        return switch (registrationId) {
+            case "kakao" -> new KakaoUserInfo(attributes);
+            // todo 구글
+            // todo 네이버
+            default -> throw new OAuth2AuthenticationException("지원하지 않는 로그인 제공자입니다: " + registrationId);
+        };
+    }
+
+    /**
+     * 사용자 존재 여부를 확인 후 없으면 자동 회원가입
+     */
+    private Users findOrRegisterUser(OAuth2UserInfo userInfo) {
+        try {
+            return userService.findExistingUser(userInfo);
+        } catch (GeneralException e) {
+            // 유저 없어서 예외 발생 시 신규 가입 처리
+            return userService.join(userInfo);
+        }
+    }
+
+    /**
+     * 확장된 인증 객체에 사용자 엔티티 추가
+     */
+    private Map<String, Object> buildExtendedAttributes(Map<String, Object> attributes, Users user) {
+        Map<String, Object> extendedAttributes = new HashMap<>(attributes);
+        extendedAttributes.put("user", user);
+        return extendedAttributes;
+    }
+
+    /**
+     * 사용자 식별을 위한 플랫폼 소셜명 추출
+     */
+    private String extractSocialAttributeName(OAuth2UserRequest userRequest) {
+        return userRequest.getClientRegistration()
+                .getProviderDetails()
+                .getUserInfoEndpoint()
+                .getUserNameAttributeName();
+    }
+
+    /**
+     * 디버깅을 위한 사용자 정보 로깅
+     */
+    private Map<String, Object> logAttributes(Map<String, Object> attributes) {
+        attributes.forEach((key, value) -> log.info("{} = {}", key, value));
+        return attributes;
+    }
+
+}

--- a/src/main/java/com/doLink_server/auth/service/AuthService.java
+++ b/src/main/java/com/doLink_server/auth/service/AuthService.java
@@ -1,0 +1,101 @@
+package com.doLink_server.auth.service;
+
+
+import com.doLink_server.auth.oauth.model.CustomOAuth2UserDetails;
+import com.doLink_server.global.common.status.ErrorStatus;
+import com.doLink_server.global.exception.GeneralException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Optional;
+
+/**
+ * 인증 관련 서비스
+ */
+@Service
+public class AuthService {
+
+    @Value("${social.kakao.admin-key}")
+    private String kakaoAdminKey;
+    @Value("${social.kakao.authorization-domain}")
+    private String kakaoBaseDomain;
+    @Value("${social.kakao.api-uri}")
+    private String kakaoUri;
+
+    /**
+     * 인증된 유저정보 조회
+     * @return String 사용자 아이디
+     * @throws GeneralException 로그인 정보 없음 또는 유저 없음
+     */
+    public String getAuthenticatedUserId() {
+        return getCurrentUserDetails()
+                .map(CustomOAuth2UserDetails::getUserId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_FOUND_USER));
+    }
+
+    /**
+     * 현재 인증된 사용자 정보 전체 반환
+     * @return Optional of CustomOAuth2UserDetails
+     */
+    private Optional<CustomOAuth2UserDetails> getCurrentUserDetails() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()
+                || "anonymousUser".equals(authentication.getPrincipal())) {
+            return Optional.empty();
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof CustomOAuth2UserDetails userDetails) {
+            return Optional.of(userDetails);
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * 소셜 인증 해제
+     * @param socialId 소셜 아이디
+     * @param socialName 소셜 명
+     */
+    public void unlinkAuthenticatedUser(String socialId, String socialName){
+
+        switch (socialName.toLowerCase()) {
+            case "kakao" -> unlinkKakao(socialId);
+            case "naver" -> throw new GeneralException(ErrorStatus._NOT_IMPLEMENTED_SOCIAL);
+            case "google" -> throw new GeneralException(ErrorStatus._NOT_IMPLEMENTED_SOCIAL);
+            default -> throw new GeneralException(ErrorStatus._UNSUPPORTED_SOCIAL_PLATFORM);
+        }
+    }
+
+    /**
+     * 카카오 인증 해제
+     * @param kakaoUserId 소셜 아이디
+     */
+    private void unlinkKakao(String kakaoUserId) {
+        try {
+            WebClient webClient = WebClient.builder()
+                    .baseUrl(kakaoBaseDomain)
+                    .defaultHeader(HttpHeaders.AUTHORIZATION, "KakaoAK " + kakaoAdminKey)
+                    .build();
+
+            webClient.post()
+                    .uri(kakaoUri)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(BodyInserters.fromFormData("target_id_type", "user_id")
+                            .with("target_id", kakaoUserId))
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block(); // 필요시 timeout 고려
+
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus._KAKAO_UNLINK_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/doLink_server/auth/service/JwtIssueService.java
+++ b/src/main/java/com/doLink_server/auth/service/JwtIssueService.java
@@ -1,0 +1,115 @@
+package com.doLink_server.auth.service;
+
+
+import com.doLink_server.global.common.status.ErrorStatus;
+import com.doLink_server.global.exception.GeneralException;
+import com.doLink_server.security.jwt.JwtProperties;
+import com.doLink_server.security.jwt.JwtProvider;
+import jakarta.servlet.http.Cookie;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * JWT 토큰 관련 서비스
+ */
+@Slf4j
+@Service
+@AllArgsConstructor
+public class JwtIssueService {
+
+    private final JwtProvider jwtProvider;
+    private final JwtProperties jwtProperties;
+
+    /**
+     * AccessToken 발급
+     * @param userId 사용자 아이디
+     * @return 액세스 토큰
+     */
+    public String issueAccessToken(String userId) {
+        return jwtProvider.createJwt(userId, jwtProperties.getAccessTokenExpiration(), "access");
+    }
+
+    /**
+     * AccessToken 재발급
+     * @param refreshToken 리프레시 토큰
+     * @return 액세스 토큰
+     */
+    public String reIssueAccessToken(String refreshToken) {
+        String userId = jwtProvider.getUserId(refreshToken);
+        validateToken(refreshToken, "refresh");
+
+        return jwtProvider.createJwt(userId, jwtProperties.getAccessTokenExpiration(), "access");
+    }
+
+    /**
+     * RefreshToken 발급
+     * @param userId 사용자 아이디
+     * @return 액세스 토큰
+     */
+    public String issueRefreshToken(String userId) {
+        long expiration = jwtProperties.getRefreshTokenExpiration();
+        return jwtProvider.createJwt(userId, expiration, "refresh");
+    }
+
+    /**
+     * 쿠키에서 RefreshToken 추출
+     * @param cookies HttpServletRequest
+     * @return 리프레시 토큰
+     */
+    public String getRefreshTokenFromCookie(Cookie[] cookies) {
+        String refreshToken = null;
+        if (cookies == null) {
+            throw new GeneralException(ErrorStatus.TOKEN_INVALIDATE_ERROR);
+        }
+
+        for (Cookie cookie : cookies) {
+            if ("refresh".equals(cookie.getName())) {
+                refreshToken = cookie.getValue();
+                break;
+            }
+        }
+        if (refreshToken == null) {
+            throw new GeneralException(ErrorStatus.ALREADY_LOGOUT);
+        }
+        return refreshToken;
+    }
+
+    /**
+     * 쿠키에서 RefreshToken 삭제
+     *
+     * @return 쿠키 객체
+     */
+    public Cookie removeRefreshTokenFromCookie() {
+        Cookie deleteCookie = new Cookie("refresh", null);
+        deleteCookie.setMaxAge(0);
+        deleteCookie.setPath("/");
+        deleteCookie.setHttpOnly(true);
+        deleteCookie.setSecure(true);
+
+        return deleteCookie;
+    }
+
+    /**
+     * 전달받은 Token의 유효성을 검증합니다.
+     * @param tokenType 클라이언트가 전달한 Refresh Token
+     * @throws GeneralException TOKEN_NOT_FOUND: 토큰이 null인 경우
+     * @throws GeneralException INVALID_TOKEN: JWT 자체가 유효하지 않거나, Redis에 저장된 토큰과 일치하지 않을 경우
+     */
+    public void validateToken(String token, String tokenType) {
+        if (token == null) {
+            throw new GeneralException(ErrorStatus.TOKEN_NOT_FOUND);
+        }
+        if (!jwtProvider.validateToken(token)) {
+            throw new GeneralException(ErrorStatus.TOKEN_SIGNATURE_ERROR);
+        }
+        if (jwtProvider.isExpired(token)) {
+            throw new GeneralException(ErrorStatus.TOKEN_EXPIRED);
+        }
+
+        String category = jwtProvider.getCategory(token);
+        if (!tokenType.equals(category)) {
+            throw new GeneralException(ErrorStatus.TOKEN_SIGNATURE_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/doLink_server/auth/service/RedisService.java
+++ b/src/main/java/com/doLink_server/auth/service/RedisService.java
@@ -1,0 +1,91 @@
+package com.doLink_server.auth.service;
+
+
+import com.doLink_server.security.jwt.JwtProperties;
+import com.doLink_server.security.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * redis 관련 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final JwtProvider jwtProvider;
+    private final JwtProperties jwtProperties;
+
+    /**
+     * Redis 키 형식 정의
+     * @param userId 사용자 아이디
+     * @return refresh token key
+     */
+    private String buildKey(String userId) {
+        return "refresh:" + userId;
+    }
+
+    /**
+     * Redis에 리프레시 토큰 삭제
+     * @param userId 사용자 식별자
+     */
+    public void removeRefreshToken(String userId) {
+        String key = buildKey(userId);
+        redisTemplate.delete(key);
+    }
+
+    /**
+     * Redis에 refresh token 저장
+     * @param userId       사용자 UUID
+     * @param refreshToken 저장할 refresh token 값
+     */
+    public void saveRefreshToken(String userId, String refreshToken) {
+        long expirationMs = jwtProperties.getRefreshTokenExpiration();
+        String key = buildKey(userId);
+        redisTemplate.opsForValue().set(key, refreshToken, expirationMs, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Redis에서 userId에 해당하는 리프레시 토큰 조회
+     * @param userId 사용자 식별자 (UUID의 문자열 표현)
+     * @return 저장된 리프레시 토큰, 없으면 null 반환
+     */
+    public String getRefreshToken(String userId) {
+        String token = getTokenFromRedis(userId);
+        log.info("Cookie stored token: '{}'", token);
+        return token;
+    }
+
+    /**
+     * Redis에 저장된 리프레시 토큰과 비교하여 유효성 체크
+     *
+     * @param userId 사용자 식별자 (UUID의 문자열 표현)
+     * @param refreshToken 클라이언트에서 전달받은 리프레시 토큰
+     * @return 유효하지 않으면 true, 유효하면 false
+     */
+    public boolean isInvalidRefreshToken(String userId, String refreshToken) {
+        String stored = getTokenFromRedis(userId);
+
+        // Redis에 저장된 토큰이 없거나, 토큰 자체가 유효하지 않거나, 두 토큰이 일치하지 않으면 유효하지 않음
+        return stored == null
+                || !jwtProvider.validateToken(stored)
+                || !jwtProvider.validateToken(refreshToken)
+                || !stored.equals(refreshToken);
+    }
+
+    /**
+     * refreshToken을 조회하는 공통 메서드
+     * @param userId 사용자 아이디
+     * @return refreshToken
+     */
+    private String getTokenFromRedis(String userId) {
+        String key = buildKey(userId);
+        return redisTemplate.opsForValue().get(key);
+    }
+}

--- a/src/main/java/com/doLink_server/security/config/SecurityConfig.java
+++ b/src/main/java/com/doLink_server/security/config/SecurityConfig.java
@@ -1,0 +1,102 @@
+package com.doLink_server.security.config;
+
+import com.doLink_server.auth.oauth.handler.CustomOAuth2ExceptionHandler;
+import com.doLink_server.auth.oauth.handler.CustomOAuth2SuccessHandler;
+import com.doLink_server.auth.oauth.service.CustomOAuth2UserService;
+import com.doLink_server.auth.service.JwtIssueService;
+import com.doLink_server.auth.service.RedisService;
+import com.doLink_server.security.entrypoint.CustomAuthenticationEntryPoint;
+import com.doLink_server.security.filter.CustomLogoutFilter;
+import com.doLink_server.security.filter.JwtAuthenticationFilter;
+import com.doLink_server.security.jwt.JwtProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
+
+import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
+
+/**
+ * 보안정책 설정 클래스
+ */
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
+    private final CustomOAuth2ExceptionHandler customOAuth2ExceptionHandler;
+    private final JwtProvider jwtProvider;
+    private final ObjectMapper objectMapper;
+    private final JwtIssueService jwtIssueService;
+    private final RedisService redisService;
+
+    @Bean
+    public JwtAuthenticationFilter jwtFilter() {
+        return new JwtAuthenticationFilter(jwtProvider, redisService, jwtIssueService);
+    }
+
+    @Bean
+    public CustomLogoutFilter customLogoutFilter() {
+        return new CustomLogoutFilter(jwtProvider, objectMapper, jwtIssueService, redisService);
+    }
+
+    /**
+     * Spring Security 필터 체인 설정
+     */
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        // CSRF 비활성화
+        http.csrf(AbstractHttpConfigurer::disable);
+
+        // 경로별 인가 설정
+        http.authorizeHttpRequests(auth -> auth
+                .requestMatchers(WHITE_LIST_URL).permitAll()
+                .anyRequest().authenticated()
+        );
+
+        // 인증 실패 시 리다이렉트 없이 401 Unauthorized 상태코드 응답
+        http.exceptionHandling(exceptionHandling -> exceptionHandling
+                .authenticationEntryPoint(new CustomAuthenticationEntryPoint(objectMapper))
+        );
+
+        // JWT 필터 설정
+        http.addFilterBefore(jwtFilter(), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(customLogoutFilter(), LogoutFilter.class);
+
+        // 세션 설정: STATELESS
+        http.sessionManagement(session -> session.sessionCreationPolicy(STATELESS));
+
+        // OAuth2 로그인 설정
+        http.oauth2Login(oauth2Configurer -> oauth2Configurer
+                .successHandler(customOAuth2SuccessHandler)
+                .failureHandler(customOAuth2ExceptionHandler)
+                .userInfoEndpoint(userInfoEndpointConfig
+                        -> userInfoEndpointConfig.userService(customOAuth2UserService))
+        );
+        return http.build();
+    }
+
+    /**
+     * OAuth 콜백 URL을 처리하기 위한 인증 우회설정
+     */
+    private static final String[] WHITE_LIST_URL = {
+            "/v1/auth/reissue",
+
+            // swagger
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+
+            // 프론트 jwt 개발배포환경
+            "/temp/login"
+    };
+}

--- a/src/main/java/com/doLink_server/security/dto/UserDTO.java
+++ b/src/main/java/com/doLink_server/security/dto/UserDTO.java
@@ -1,0 +1,17 @@
+package com.doLink_server.security.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 인증 시 사용자 식별 정보 전달용 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserDTO {
+    private String userId;
+}

--- a/src/main/java/com/doLink_server/security/entrypoint/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/doLink_server/security/entrypoint/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,47 @@
+package com.doLink_server.security.entrypoint;
+
+import com.doLink_server.global.common.ApiResponse;
+import com.doLink_server.global.common.status.ErrorStatus;
+import com.doLink_server.security.exception.CustomAuthenticationException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * 인증되지 않은 사용자가 보호된 리소스에 접근할 때 호출되는 EntryPoint
+ */
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+
+        ErrorStatus status;
+
+        // CustomAuthenticationException 이라면 우리가 설정한 ErrorStatus 사용
+        if (authException instanceof CustomAuthenticationException customEx) {
+            status = customEx.getErrorStatus();
+        } else {
+            // 그 외 기본 인증 실패
+            status = ErrorStatus._UNAUTHORIZED;
+        }
+
+        ApiResponse<?> apiResponse = ApiResponse.onFailure(status.getCode(), status.getMessage());
+
+        response.setStatus(status.getHttpStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
+    }
+}

--- a/src/main/java/com/doLink_server/security/exception/CustomAuthenticationException.java
+++ b/src/main/java/com/doLink_server/security/exception/CustomAuthenticationException.java
@@ -1,0 +1,20 @@
+package com.doLink_server.security.exception;
+
+
+import com.doLink_server.global.common.status.ErrorStatus;
+import lombok.Getter;
+import org.springframework.security.core.AuthenticationException;
+
+/**
+ * Spring Security 인증 실패 예외
+ */
+@Getter
+public class CustomAuthenticationException extends AuthenticationException {
+
+    private final ErrorStatus errorStatus;
+
+    public CustomAuthenticationException(ErrorStatus errorStatus) {
+        super(errorStatus.getMessage());
+        this.errorStatus = errorStatus;
+    }
+}

--- a/src/main/java/com/doLink_server/security/filter/CustomLogoutFilter.java
+++ b/src/main/java/com/doLink_server/security/filter/CustomLogoutFilter.java
@@ -1,0 +1,99 @@
+package com.doLink_server.security.filter;
+
+import com.doLink_server.auth.service.JwtIssueService;
+import com.doLink_server.auth.service.RedisService;
+import com.doLink_server.global.common.ApiResponse;
+import com.doLink_server.global.common.status.ErrorStatus;
+import com.doLink_server.global.exception.GeneralException;
+import com.doLink_server.security.jwt.JwtProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+/**
+ * OAuth 로그아웃 필터
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class CustomLogoutFilter extends GenericFilterBean {
+
+    private final JwtProvider jwtProvider;
+    private final ObjectMapper objectMapper;
+    private final JwtIssueService jwtIssueService;
+    private final RedisService redisService;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        handleLogout((HttpServletRequest) request, (HttpServletResponse) response, chain);
+    }
+
+    /**
+     * 로그아웃 요청 처리 메서드
+
+     * 요청 URI와 HTTP 메서드를 확인하여 로그아웃 API 요청인지 판단합니다.
+     * 로그아웃 요청인 경우, 쿠키에서 refresh 토큰을 추출하고 유효성 검증을 수행합니다.
+     * Redis에 저장된 토큰과 일치하는지 확인 후 로그아웃 처리(토큰 삭제, 쿠키 만료 설정)를 진행합니다.
+     * 로그아웃이 아닌 요청은 다음 필터로 정상적으로 전달합니다.
+     *
+     * @param request     HTTP 요청 객체 (토큰 쿠키 추출 및 요청 정보 확인용)
+     * @param response    HTTP 응답 객체 (로그아웃 결과 전송용)
+     * @param filterChain 다음 필터 또는 리소스로 요청 전달용 체인
+     * @throws IOException      입출력 예외 발생 시 던짐
+     * @throws ServletException 서블릿 처리 중 예외 발생 시 던짐
+     */
+    public void handleLogout(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws IOException, ServletException {
+
+        // 1. 로그아웃 요청이 아닌 경우, 다음 필터로 전달
+        log.info("Request URI: {}", request.getRequestURI());
+        log.info("Request Method: {}", request.getMethod());
+
+        if (!"/v1/user/logout".equals(request.getRequestURI()) || !"POST".equalsIgnoreCase(request.getMethod())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 2. 쿠키에서 refresh 토큰 추출
+        try{
+            Cookie[] cookies = request.getCookies();
+            String refreshToken = jwtIssueService.getRefreshTokenFromCookie(cookies);
+
+            // Redis에 저장된 refresh 토큰 확인
+            String userId = jwtProvider.getUserId(refreshToken);
+            if(redisService.isInvalidRefreshToken(userId, refreshToken)){
+                log.error("Redis에 저장된 RefreshToken과 불일치");
+                throw new GeneralException(ErrorStatus.TOKEN_INVALIDATE_ERROR);
+            }
+            // Redis 토큰 삭제 (로그아웃)
+            redisService.removeRefreshToken(userId);
+
+        } catch (ExpiredJwtException e) {
+            ApiResponse.sendErrorResponse(response, ErrorStatus.TOKEN_EXPIRED.getReasonHttpStatus(), objectMapper);
+            return;
+        } catch (GeneralException e) {
+            ApiResponse.sendErrorResponse(response, e.getErrorReasonHttpStatus(), objectMapper);
+            return;
+        }
+
+        // 3. 쿠키 삭제
+        Cookie initCookie = jwtIssueService.removeRefreshTokenFromCookie();
+        response.addCookie(initCookie);
+
+        // 성공 응답
+        ApiResponse.sendSuccessResponse(response, "로그아웃이 완료되었습니다.", objectMapper);
+    }
+
+}

--- a/src/main/java/com/doLink_server/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/doLink_server/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,86 @@
+package com.doLink_server.security.filter;
+
+
+import com.doLink_server.auth.oauth.model.CustomOAuth2UserDetails;
+import com.doLink_server.auth.service.JwtIssueService;
+import com.doLink_server.auth.service.RedisService;
+import com.doLink_server.security.dto.UserDTO;
+import com.doLink_server.security.exception.CustomAuthenticationException;
+import com.doLink_server.security.jwt.JwtProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * JWT 토큰 인증을 위한 필터
+ */
+@Slf4j
+@AllArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final RedisService redisService;
+    private final JwtIssueService jwtIssueService;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        // jwt 기간 만료시, 무한 재로그인 방지 로직
+        String requestUri = request.getRequestURI();
+        if (requestUri.matches("^/login(?:/.*)?$") || requestUri.matches("^/oauth2(?:/.*)?$") ||
+                requestUri.matches("^/v1/auth/reissue$")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 1. Access Token 추출 (header: Authorization)
+        String accessToken = request.getHeader("Authorization");
+        log.info("[JwtFilter] accessToken from header: {}", accessToken);
+        if (accessToken == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        // "Bearer " 접두어 제거
+        if (accessToken.startsWith("Bearer ")) {
+            accessToken = accessToken.substring(7);
+        }
+
+        try {
+            // ✅ [1] Access Token 유효성 검증 (유효하지 않으면 예외 던짐)
+            jwtIssueService.validateToken(accessToken, "access");
+
+            // ✅ [2] 사용자 정보 추출
+            String userId = jwtProvider.getUserId(accessToken);
+
+            // ✅ [3] 사용자 정보 객체 설정 및 SecurityContext에 인증 객체 저장
+            UserDTO userDTO = new UserDTO();
+            userDTO.setUserId(userId);
+            CustomOAuth2UserDetails customUser = new CustomOAuth2UserDetails(userDTO);
+
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                    customUser, null, customUser.getAuthorities()
+            );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        } catch (CustomAuthenticationException ex) {
+            // ✅ [4] AuthenticationException 으로 래핑해서 EntryPoint로 위임
+            SecurityContextHolder.clearContext(); // 중요: 인증 실패 시 Context 초기화
+            throw ex; // 🔥 여기서 EntryPoint로 위임되도록 던짐!
+        }
+
+        // 7. 필터 체인 계속 진행
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/doLink_server/security/jwt/JwtProperties.java
+++ b/src/main/java/com/doLink_server/security/jwt/JwtProperties.java
@@ -1,0 +1,19 @@
+package com.doLink_server.security.jwt;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * JWT 토큰 프로퍼티
+ */
+@Component
+@Getter
+public class JwtProperties {
+
+    @Value("${spring.jwt.access-expiration-time}")
+    private long accessTokenExpiration;
+
+    @Value("${spring.jwt.refresh-expiration-time}")
+    private long refreshTokenExpiration;
+}

--- a/src/main/java/com/doLink_server/security/jwt/JwtProvider.java
+++ b/src/main/java/com/doLink_server/security/jwt/JwtProvider.java
@@ -1,0 +1,158 @@
+package com.doLink_server.security.jwt;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Optional;
+
+/**
+ * JWT 토큰 생성 및 파싱 클래스
+ */
+@Slf4j
+@Component
+public class JwtProvider {
+
+    // 서명을 위한 SecretKey 객체 (HMAC 방식)
+    private SecretKey secretKey;
+
+    @Value("${spring.jwt.secret}")
+    private String secret;
+
+    private final ObjectMapper objectMapper;
+
+    public JwtProvider(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * 생성자 후 초기화: secret 값을 SecretKey 객체로 변환
+     */
+    @PostConstruct
+    protected void init() {
+        byte[] decodedKey = Base64.getDecoder().decode(secret);
+        // secret 문자열을 바이트로 변환하여 SecretKey 생성
+        this.secretKey = Keys.hmacShaKeyFor(decodedKey);
+        log.info("[JwtUtil:init] secret(raw): {}", secret);
+        log.info("[JwtUtil:init] secret(decoded base64 length): {}", decodedKey.length);
+    }
+
+    /**
+     * JWT 토큰에서 Claims 파싱 (서명 검증 포함)
+     * @param token JWT 토큰 문자열
+     * @return Claims 객체
+     */
+    private Claims parseClaims(String token) {
+        try {
+            return Jwts.parser()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (ExpiredJwtException e) {
+            // 토큰이 만료됐어도 Claims는 반환
+            return e.getClaims();
+        }
+    }
+
+    /**
+     * 토큰에서 userId 추출
+     * @param token JWT 토큰 문자열
+     * @return userId 클레임 값(UUID)
+     */
+    public String getUserId(String token) {
+        try {
+            Claims claims = parseClaims(token);
+            String idStr = claims.get("userId", String.class);
+
+            if (idStr == null) {
+                throw new IllegalArgumentException("userId 클레임이 존재하지 않습니다.");
+            }
+
+            return idStr;
+        } catch (Exception e) {
+            // 여기서 로그로 디버깅
+            log.error("JWT에서 userId 추출 실패 token : {}", token);
+            log.error("JWT에서 userId 추출 실패: {}", e.getMessage(), e);
+            throw e; // 나중에 커스텀 예외로 변경 가능
+        }
+    }
+
+    /**
+     * 토큰에서 category(access/refresh) 추출
+     * @param token JWT 토큰 문자열
+     * @return category 클레임 값
+     */
+    public String getCategory(String token) {
+        return parseClaims(token).get("category", String.class);
+    }
+
+    /**
+     * 토큰 만료 여부 확인
+     * @param token JWT 토큰 문자열
+     * @return true: 만료됨, false: 아직 유효함
+     */
+    public boolean isExpired(String token) {
+        Date expiration = parseClaims(token).getExpiration();
+        return expiration.before(new Date());
+    }
+
+    /**
+     * JWT 토큰 생성
+     * @param userId 사용자 아이디(UUID)
+     * @param expiredMs 토큰 유효 시간 (밀리초 단위)
+     * @param category access 또는 refresh 등 토큰 용도
+     * @return 서명된 JWT 토큰 문자열
+     */
+    public String createJwt(String userId, Long expiredMs, String category) {
+        log.info("NEW 토큰 발행 합니다 !!!!!!!!!!!!!! ");
+        return Jwts.builder()
+                .claim("userId", userId) // UUID를 문자열로 넣기
+                .claim("category", category)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiredMs)) // 만료 시각
+                .signWith(secretKey) // 서명
+                .compact();          // JWT 문자열 생성
+    }
+
+    /**
+     * 토큰 유효성 검증 (서명 검사)
+     * @param token JWT 토큰 문자열
+     * @return true: 유효함, false: 유효하지 않음
+     */
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (Exception e) {
+            log.error("JWT 유효성 검사 실패: {}", e.getMessage()); // 꼭 찍어야 함
+            return false;
+        }
+    }
+
+    /**
+     * JWT 토큰의 Claims(payload)를 JSON 형식으로 반환한다.
+     * @param token JWT 토큰 문자열
+     * @return Claims JSON 문자열, 파싱 실패시 Optional.empty()
+     */
+    public Optional<String> extractClaimsAsJson(String token) {
+        try {
+            Claims claims = parseClaims(token);
+            String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(claims);
+            return Optional.of(json);
+        } catch (JwtException | JsonProcessingException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/doLink_server/user/controller/UserController.java
+++ b/src/main/java/com/doLink_server/user/controller/UserController.java
@@ -1,0 +1,70 @@
+package com.doLink_server.user.controller;
+
+import com.doLink_server.auth.service.AuthService;
+import com.doLink_server.global.common.ApiResponse;
+import com.doLink_server.global.exception.GeneralException;
+import com.doLink_server.user.dto.UserRequest;
+import com.doLink_server.user.dto.UserResponse;
+import com.doLink_server.user.entity.Users;
+import com.doLink_server.user.service.UserService;
+import com.doLink_server.user.usecase.UserUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 사용자 관련 컨트롤러
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/user")
+@Tag(name = "User", description = "사용자 관련 API")
+public class UserController {
+
+    private final UserUseCase userUseCase;
+    private final UserService userService;
+    private final AuthService authService;
+
+    /**
+     * 현재 로그인한 사용자 정보
+     * @return 로그인 사용자 정보 또는 로그인 요청 메시지
+     */
+    @GetMapping("/profile")
+    @Operation(summary = "사용자 정보", description = "현재 로그인한 사용자의 정보를 반환한다.")
+    public ApiResponse<UserResponse> getUser() {
+
+        // 인증객체에서 사용자 아이디 가져오기
+        String userId = authService.getAuthenticatedUserId();
+        Users loginUser = userService.findExistingUser(userId);
+        UserResponse userResponse = UserResponse.fromEntity(loginUser);
+        return ApiResponse.onSuccess(userResponse);
+    }
+
+    /**
+     * 로그아웃
+     */
+    @Operation(summary = "로그아웃", description = "Security 로그아웃 필터를 실행한다.")
+    @PostMapping("/logout")
+    public void logout() {}
+
+    /**
+     * 서비스 탈퇴
+     */
+    @Operation(summary = "회원탈퇴", description = "서비스를 탈퇴한다.")
+    @DeleteMapping("/profile")
+    public ResponseEntity<ApiResponse<String>> withdraw() {
+        String userId = authService.getAuthenticatedUserId();
+        userUseCase.withdrawUser(userId);
+
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess("회원 탈퇴가 완료되었습니다.")
+        );
+    }
+
+
+}

--- a/src/main/java/com/doLink_server/user/dto/UserRequest.java
+++ b/src/main/java/com/doLink_server/user/dto/UserRequest.java
@@ -1,0 +1,21 @@
+package com.doLink_server.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+/**
+ * 사용자 프로필 정보 요청 DTO
+ */
+@Getter
+public class UserRequest {
+
+    @NotBlank(message = "닉네임은 필수입니다.")
+    private String nickname;
+
+    @NotBlank(message = "프로필 이미지 아이디는 필수입니다.")
+    private String profileImageUrl;
+
+    @NotNull(message = "푸시알람 여부는 필수입니다.")
+    private boolean pushNotificationEnabled;
+}

--- a/src/main/java/com/doLink_server/user/dto/UserResponse.java
+++ b/src/main/java/com/doLink_server/user/dto/UserResponse.java
@@ -1,0 +1,25 @@
+package com.doLink_server.user.dto;
+
+import com.doLink_server.user.entity.Users;
+
+public record UserResponse(
+        String socialName,
+        String nickname,
+        String email,
+        String profileImageUrl
+) {
+    /**
+     * 엔티티 → DTO 변환 팩토리 메서드
+     * @param user 사용자 객체
+     * @return 사용자 응답정보
+     */
+    public static UserResponse fromEntity(Users user) {
+        return new UserResponse(
+                user.getSocialName(),
+                user.getNickname(),
+                user.getEmail(),
+                user.getProfileImageUrl()
+        );
+    }
+
+}

--- a/src/main/java/com/doLink_server/user/entity/Users.java
+++ b/src/main/java/com/doLink_server/user/entity/Users.java
@@ -1,0 +1,126 @@
+package com.doLink_server.user.entity;
+
+import com.doLink_server.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 사용자 기본정보 테이블
+ */
+@Getter
+@Setter
+@Entity
+@Builder
+@Table(name = "users", schema = "talktodo")
+@NoArgsConstructor
+@AllArgsConstructor
+public class Users extends BaseEntity {
+
+    /**
+     * 사용자 ID (연관관계 X, 단방향 UUID 관리)
+     */
+    @Id
+    @Column(name = "user_id", nullable = false, length = 16)
+    private byte[] userId;
+
+
+    @Column(name = "task_id", columnDefinition = "BINARY(16)")
+    private UUID taskId;
+
+    /**
+     * 할 일 모음 ID
+     */
+    @Column(name = "collection_id", nullable = true)
+    private Long collectionId;
+
+    /**
+     * 소셜 로그인 제공 ID
+     */
+    @Column(name = "social_id", nullable = false, length = 10)
+    private String socialId;
+
+    /**
+     * 소셜 명
+     */
+    @Column(name = "social_name", nullable = false, length = 8)
+    private String socialName;
+
+    /**
+     * 사용자 이메일주소
+     */
+    @Column(name = "email", nullable = false, length = 30)
+    private String email;
+
+    /**
+     * 계정 활성화 여부
+     */
+    @Column(name = "is_active", nullable = false)
+    @Builder.Default
+    private Boolean isActive = false;
+
+    /**
+     * 프로필 이미지 URL 경로
+     */
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;
+
+    /**
+     * 사용자 닉네임
+     */
+    @Column(name = "nickname", nullable = false, length = 15)
+    private String nickname;
+
+    /**
+     * 할 일 제목
+     */
+    @Column(name = "title")
+    private String title;
+
+    /**
+     * 관련 링크
+     */
+    @Column(name = "link")
+    private String link;
+
+    /**
+     * 메모
+     */
+    @Column(name = "memo")
+    private String memo;
+
+    /**
+     * 완료 상태
+     */
+    @Column(name = "status")
+    private Boolean status;
+
+    /**
+     * 내부 / 외부 구분
+     */
+    @Column(name = "in_out")
+    private Boolean inout;
+
+    /**
+     * 생성일
+     */
+    @NotNull
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    /**
+     * 수정일
+     */
+    @NotNull
+    @Column(name = "modified_at", nullable = false)
+    private LocalDateTime modifiedAt;
+
+
+}

--- a/src/main/java/com/doLink_server/user/repository/UsersRepository.java
+++ b/src/main/java/com/doLink_server/user/repository/UsersRepository.java
@@ -1,0 +1,23 @@
+package com.doLink_server.user.repository;
+
+
+
+import com.doLink_server.user.entity.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * 사용자 레포지토리
+ */
+@Repository
+public interface UsersRepository extends JpaRepository<Users, UUID> {
+    // socialId로 사용자 조회
+    Optional<Users> findBySocialId(String socialId);
+    // userId 사용자 조회
+    Optional<Users> findByUserId(byte[] userId);
+
+    Optional<Users> findBySocialIdAndSocialName(String socialId, String socialName);
+}

--- a/src/main/java/com/doLink_server/user/service/UserService.java
+++ b/src/main/java/com/doLink_server/user/service/UserService.java
@@ -1,0 +1,80 @@
+package com.doLink_server.user.service;
+
+import com.doLink_server.auth.oauth.model.OAuth2UserInfo;
+import com.doLink_server.global.common.status.ErrorStatus;
+import com.doLink_server.global.exception.GeneralException;
+import com.doLink_server.global.util.UUIDToBytesUtil;
+import com.doLink_server.user.entity.Users;
+import com.doLink_server.user.repository.UsersRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+public class UserService {
+
+    private final UsersRepository usersRepository;
+
+    public UserService(UsersRepository usersRepository) {
+        this.usersRepository = usersRepository;
+    }
+
+    /**
+     * 기존 사용자 확인
+     *
+     * @param userInfo OAuth2 소셜 사용자 정보
+     * @return 사용자 응답객체
+     */
+    public Users findExistingUser(OAuth2UserInfo userInfo) {
+        return usersRepository.findBySocialId(userInfo.getProviderId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_FOUND_USER));
+    }
+
+    /**
+     * 기존 사용자 확인
+     *
+     * @param userId 사용자 아이디
+     * @return 사용자 응답객체
+     */
+    public Users findExistingUser(String userId) {
+        return usersRepository.findByUserId(UUIDToBytesUtil.convertToDatabaseColumn(userId))
+                .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_FOUND_USER));
+    }
+
+    /**
+     * 신규 가입 처리
+     * @param userInfo OAuth2 소셜 사용자 정보
+     * @return 사용자 응답객체
+     */
+    public Users join(OAuth2UserInfo userInfo) {
+
+        UUID userId = UUID.randomUUID();
+        Users user = Users.builder()
+                .userId(UUIDToBytesUtil.convertToDatabaseColumn(userId)) // UUID를 BINARY(16)로 저장
+                .socialId(userInfo.getProviderId())
+                .socialName(userInfo.getProvider())
+                .nickname(userInfo.getNickname())
+                .email(userInfo.getEmail())
+                .isActive(true)
+                .profileImageUrl(userInfo.getProfileImageUrl())
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build();
+        usersRepository.save(user);
+        return user;
+    }
+
+    /**
+     * 탈퇴처리
+     */
+    public void withdraw(String userId){
+
+        Users user = findExistingUser(userId);
+
+        usersRepository.delete(user);
+
+    }
+
+
+}

--- a/src/main/java/com/doLink_server/user/usecase/UserUseCase.java
+++ b/src/main/java/com/doLink_server/user/usecase/UserUseCase.java
@@ -1,0 +1,40 @@
+package com.doLink_server.user.usecase;
+
+import com.doLink_server.auth.service.AuthService;
+import com.doLink_server.global.common.status.ErrorStatus;
+import com.doLink_server.global.exception.GeneralException;
+import com.doLink_server.user.entity.Users;
+import com.doLink_server.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserUseCase {
+
+    private final AuthService authService;
+    private final UserService userService;
+
+    /**
+     * 회원 탈퇴 전용 트랜잭션 로직
+     */
+    @Transactional
+    public void withdrawUser(String userId) {
+        Users loginUser = userService.findExistingUser(userId);
+
+        try {
+            // 1. 소셜 인증 해제
+            authService.unlinkAuthenticatedUser(
+                    loginUser.getSocialId(),
+                    loginUser.getSocialName()
+            );
+
+            // 2. 사용자 데이터 삭제 (연관 테이블 포함)
+            userService.withdraw(userId);
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus._WITHDRAW_FAILED);
+        }
+    }
+
+}


### PR DESCRIPTION
## 🔢 Issue Number
- #7

## 🎯 기능 개요
- **목적**: Spring Security + OAuth2 로그인 도입 및 JWT 기반 인증 플로우 구축
주요 기능
- OAuth2 로그인 성공 시 Refresh Token을 HttpOnly 쿠키로 발급/저장
- Refresh Token을 Redis에 저장하고, 쿠키 토큰과 일치 검증
- Access Token 만료 시 /v1/auth/reissue로 재발급
- /v1/user/logout 요청 시 Redis 토큰 삭제 + 쿠키 만료 처리
- 인증 실패 시 리다이렉트가 아닌 JSON 401 응답(EntryPoint) 처리
- /v1/user/profile에서 현재 로그인 유저 정보 조회 제공

## 🏗 구현 상세 및 설계 문서
의존성/부트 설정
build.gradle - Spring Security / OAuth2 Client 활성화
DoLinkApplication - @EnableJpaAuditing 추가 (생성/수정 시간 자동 관리)

CustomOAuth2UserService
- 제공자별 사용자 정보 파싱(KakaoUserInfo)

## 🧪 테스트 계획 및 결과
- 카카오 로컬테스트 성공
<img width="2880" height="494" alt="image" src="https://github.com/user-attachments/assets/e932bff9-f95e-4c71-bfe8-c0f2aa40c893" />

## 🔍 사이드 이펙트 분석
쿠키 도메인/secure 설정
auth.cookie.domain, prod profile에서 secure=true → 로컬/개발 환경에서 쿠키 미설정 이슈 가능

## 💌 To Reviewers

[IN_OUT 예약어 문제]
지금은 “테이블이 안 만들어지는 문제”가 아니라, **DDL 생성 자체가 실패**해서 `users` 테이블이 못 생기는 문제 있었음.
- `drop table if exists users` ✅ 성공
- `create table users (...)` ❌ 실패
- 실패 이유: **SQL 문법 오류 1064**가 `inout bit, ...` **라인 2 근처**에서 발생
즉, `users` 테이블 생성 SQL의 **첫 컬럼명 `inout`이 MariaDB에서 예약어/문법 충돌**이라서 파싱이 깨짐
inout -> in_out

[카카오 디벨로퍼스 UI 바뀜 - 리다이렉트 URI 못찾았음]
플랫폼키의 어드민키 눌러서 내부들어가서 추가 

[애플, 네이버 로그인 구현 추가 필요]
일단 -> 기능구현이 최우선이라 기능구현 먼저하고 붙히기로 했습니다.