### PR TITLE
Feat/collection crud

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation' // No Jakarta Bean Validation provider could be found 에러나서 추가함
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -43,6 +44,8 @@ dependencies {
 	// DB
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'  // JDBC API
 	implementation 'org.mariadb.jdbc:mariadb-java-client:3.1.4' // MariaDB JDBC 드라이버
+	implementation 'org.flywaydb:flyway-core' // DB 스키마 변경(인덱스 포함)을 버전 관리
+	implementation 'org.flywaydb:flyway-mysql'
 
 	// JPA
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")

--- a/src/main/java/com/doLink_server/domain/collection/controller/CollectionController.java
+++ b/src/main/java/com/doLink_server/domain/collection/controller/CollectionController.java
@@ -1,0 +1,119 @@
+package com.doLink_server.domain.collection.controller;
+
+import com.doLink_server.domain.collection.dto.CollectionCreateRequest;
+import com.doLink_server.domain.collection.dto.CollectionResponse;
+import com.doLink_server.domain.collection.dto.CollectionSimpleResponse;
+import com.doLink_server.domain.collection.dto.CollectionUpdateRequest;
+import com.doLink_server.domain.collection.service.CollectionService;
+import com.doLink_server.global.common.ApiResponse;
+import com.doLink_server.global.enums.Category;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 모음 컨트롤러
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/collect")
+@Tag(name = "Collection", description = "모음 관련 API")
+public class CollectionController {
+
+    private final CollectionService collectionService;
+
+    /**
+     * 모음 생성
+     */
+    @PostMapping
+    @Operation(summary = "모음 생성", description = "새로운 모음을 생성한다.")
+    public ApiResponse<CollectionResponse> createCollect(
+            @Valid @RequestBody CollectionCreateRequest request) {
+        return ApiResponse.onSuccess(collectionService.createCollect(request));
+    }
+
+    /**
+     * 모음 삭제
+     */
+    @DeleteMapping("/{collectId}")
+    @Operation(summary = "모음 삭제", description = "collectId에 해당하는 모음을 삭제한다.")
+    public ApiResponse<String> deleteCollect(@PathVariable("collectId") Long collectId) {
+        collectionService.deleteCollect(collectId);
+        return ApiResponse.onSuccess("모음 삭제 완료");
+    }
+
+    /**
+     * 모음 수정
+     * - UI: 모음 수정 바텀시트에서 이름/카테고리 수정
+     *
+     * PATCH /api/v1/collect/{collectId}
+     */
+    @PatchMapping("/{collectId}")
+    @Operation(summary = "모음 수정", description = "collectId에 해당하는 모음의 이름/카테고리를 수정한다.")
+    public ApiResponse<CollectionResponse> updateCollect(
+            @PathVariable Long collectId,
+            @Valid @RequestBody CollectionUpdateRequest request
+    ) {
+        return ApiResponse.onSuccess(collectionService.updateCollect(collectId, request));
+    }
+
+    /**
+     * 카테고리별 모음 조회 (무한 스크롤)
+     * /api/v1/collect/category?category=FOOD&page=0&size=10
+     */
+    @GetMapping("/category")
+    @Operation(summary = "카테고리별 모음 조회 (무한 스크롤)")
+    public ApiResponse<Slice<CollectionResponse>> listByCategory(
+            @RequestParam Category category,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ApiResponse.onSuccess(collectionService.listByCategorySlice(category, page, size));
+    }
+
+    /**
+     * 모음 전체 조회 (무한 스크롤)
+     * /api/v1/collect/all?page=0&size=10
+     */
+    @GetMapping("/all")
+    @Operation(summary = "모음 전체 조회 (무한 스크롤)")
+    public ApiResponse<Slice<CollectionResponse>> listAll(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ApiResponse.onSuccess(collectionService.listAllSlice(page, size));
+    }
+
+    /**
+     * 모음 선택 목록 조회
+     * - 할 일 추가 화면에서 "담을 모음 선택"에 사용
+     */
+    @GetMapping("/select")
+    @Operation(
+            summary = "모음 선택 목록 조회",
+            description = "할 일 추가 화면에서 '담을 모음 선택'에 사용할 모음 목록(id, 이름)을 조회한다."
+    )
+    public ApiResponse<List<CollectionSimpleResponse>> listCollectSelectOptions() {
+        return ApiResponse.onSuccess(collectionService.listCollectOptions());
+    }
+
+//
+//    /**
+//     * 모음 상세 조회
+//     */
+//    @GetMapping("/{collectId}")
+//    @Operation(summary = "모음 상세 조회", description = "collectId에 해당하는 모음 상세 정보를 조회한다.")
+//    public ApiResponse<CollectionResponse> get(
+//            @PathVariable Long collectId
+//    ) {
+//        byte[] userId = getCurrentUserId(); // TODO: Security에서 가져오기
+//        return ApiResponse.onSuccess(collectionService.get(userId, collectId));
+//    }
+//
+
+}

--- a/src/main/java/com/doLink_server/domain/collection/dto/CollectionCreateRequest.java
+++ b/src/main/java/com/doLink_server/domain/collection/dto/CollectionCreateRequest.java
@@ -1,0 +1,22 @@
+package com.doLink_server.domain.collection.dto;
+
+import com.doLink_server.global.enums.Category;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+/**
+ * 모음 생성 요청 DTO
+ */
+@Builder
+public record CollectionCreateRequest(
+
+        @NotBlank
+        @Size(max = 20)
+        String name,        // 모음 이름(필수, 최대 20자)
+
+        @NotNull
+        Category category   // 모음 카테고리(필수)
+) {
+}

--- a/src/main/java/com/doLink_server/domain/collection/dto/CollectionResponse.java
+++ b/src/main/java/com/doLink_server/domain/collection/dto/CollectionResponse.java
@@ -1,0 +1,18 @@
+package com.doLink_server.domain.collection.dto;
+
+import com.doLink_server.global.enums.Category;
+import lombok.Builder;
+
+import java.util.List;
+
+/**
+ * 모음 응답 DTO
+ */
+@Builder
+public record CollectionResponse (
+        Long collectionId,     // 모음 ID
+        String name,           // 모음 이름
+        Category category,     // 모음 카테고리
+        List<String> thumbnails // 모음에 속한 할 일들의 대표 썸네일 URL 목록 (최대 4개)
+){
+}

--- a/src/main/java/com/doLink_server/domain/collection/dto/CollectionSimpleResponse.java
+++ b/src/main/java/com/doLink_server/domain/collection/dto/CollectionSimpleResponse.java
@@ -1,0 +1,15 @@
+package com.doLink_server.domain.collection.dto;
+
+import lombok.Builder;
+
+/**
+ * 모음 선택 UI용 간단 응답 DTO
+ * - "할 일 추가" 화면에서 "담을 모음 선택" 목록에 사용
+ * - 전체 모음에서 필요한 필드만 내려준다 (id, name)
+ */
+@Builder
+public record CollectionSimpleResponse(
+        Long collectionId,
+        String name
+) {
+}

--- a/src/main/java/com/doLink_server/domain/collection/dto/CollectionUpdateRequest.java
+++ b/src/main/java/com/doLink_server/domain/collection/dto/CollectionUpdateRequest.java
@@ -1,0 +1,28 @@
+package com.doLink_server.domain.collection.dto;
+
+import com.doLink_server.global.enums.Category;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 모음 수정 요청 DTO
+ *
+ * - 모음 이름(name)과 카테고리(category)를 수정한다.
+ * - UI 스펙: 이름 필수(최대 20자), 카테고리 필수
+ */
+public record CollectionUpdateRequest(
+        /**
+         * 모음 이름 (필수)
+         */
+        @NotBlank(message = "모음 이름은 필수입니다.")
+        @Size(max = 20, message = "모음 이름은 최대 20자까지 가능합니다.")
+        String name,
+
+        /**
+         * 모음 카테고리 (필수)
+         */
+        @NotNull(message = "카테고리는 필수입니다.")
+        Category category
+) {
+}

--- a/src/main/java/com/doLink_server/domain/collection/entity/Collection.java
+++ b/src/main/java/com/doLink_server/domain/collection/entity/Collection.java
@@ -3,10 +3,13 @@ package com.doLink_server.domain.collection.entity;
 
 import com.doLink_server.global.common.BaseEntity;
 import com.doLink_server.global.enums.Category;
+import com.doLink_server.user.entity.Users;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 
 /**
@@ -16,7 +19,7 @@ import lombok.*;
 @Setter
 @Entity
 @Builder
-@Table(name = "collection", schema = "talktodo")
+@Table(name = "collection", schema = "dolink")
 @NoArgsConstructor
 @AllArgsConstructor
 public class Collection extends BaseEntity {
@@ -46,12 +49,11 @@ public class Collection extends BaseEntity {
     private Category category;
 
     /**
-     * 사용자 ID (UUID, BINARY 16)
+     * 사용자 (Users 1 : Collection N)
      */
-    @Column(name = "user_id", nullable = false, columnDefinition = "BINARY(16)")
-    private byte[] userId;
-
-
-
-
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "user_id", nullable = false, columnDefinition = "BINARY(16)")
+    private Users user;
 }

--- a/src/main/java/com/doLink_server/domain/collection/entity/Collection.java
+++ b/src/main/java/com/doLink_server/domain/collection/entity/Collection.java
@@ -1,0 +1,57 @@
+package com.doLink_server.domain.collection.entity;
+
+
+import com.doLink_server.global.common.BaseEntity;
+import com.doLink_server.global.enums.Category;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+
+/**
+ * 모음 테이블
+ */
+@Getter
+@Setter
+@Entity
+@Builder
+@Table(name = "collection", schema = "talktodo")
+@NoArgsConstructor
+@AllArgsConstructor
+public class Collection extends BaseEntity {
+
+    /**
+     * 모음 ID
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "collection_id")
+    private Long collectionId;
+
+    /**
+     * 모음 이름
+     */
+    @NotNull
+    @Size(max = 20)
+    @Column(name = "name", nullable = false, length = 20)
+    private String name;
+
+    /**
+     * 모음 카테고리
+     */
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false, length = 30)
+    private Category category;
+
+    /**
+     * 사용자 ID (UUID, BINARY 16)
+     */
+    @Column(name = "user_id", nullable = false, columnDefinition = "BINARY(16)")
+    private byte[] userId;
+
+
+
+
+}

--- a/src/main/java/com/doLink_server/domain/collection/repository/CollectionRepository.java
+++ b/src/main/java/com/doLink_server/domain/collection/repository/CollectionRepository.java
@@ -1,0 +1,67 @@
+package com.doLink_server.domain.collection.repository;
+
+import com.doLink_server.domain.collection.entity.Collection;
+import com.doLink_server.global.enums.Category;
+import com.doLink_server.user.entity.Users;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 모음 레포지토리
+ */
+public interface CollectionRepository extends JpaRepository<Collection, Long> {
+
+    /**
+     * 로그인한 사용자의 모음 전체 조회 (무한 스크롤)
+     * - 생성일자 최신 순
+     */
+    Slice<Collection> findAllByUserOrderByCreatedAtDesc(
+            Users user,
+            Pageable pageable
+    );
+
+    /**
+     * 로그인한 사용자의 카테고리별 모음 조회 (무한 스크롤)
+     * - 생성일자 최신 순
+     */
+    Slice<Collection> findAllByUserAndCategoryOrderByCreatedAtDesc(
+            Users user,
+            Category category,
+            Pageable pageable
+    );
+
+    /**
+     * 사용자별 모음 목록 조회
+     *
+     * Users (1) : Collection (N)
+     * - Collection.user -> Users
+     * - Users.userId(byte[]) 기준으로 조회
+     */
+    List<Collection> findAllByUser_UserId(byte[] userId);
+
+    /**
+     * 모음 단건 조회 (User까지 fetch join)
+     * - 삭제/수정 등 권한 체크 시 Lazy 로딩 추가 쿼리를 방지하기 위함
+     */
+    @Query("""
+        select c
+        from Collection c
+        join fetch c.user u
+        where c.collectionId = :collectionId
+    """)
+    Optional<Collection> findByIdWithUser(Long collectionId);
+
+    /**
+     * 모음 선택 UI용
+     * - 로그인 사용자의 모음 전체 조회
+     */
+    List<Collection> findAllByUser(Users user);
+
+
+}

--- a/src/main/java/com/doLink_server/domain/collection/service/CollectionService.java
+++ b/src/main/java/com/doLink_server/domain/collection/service/CollectionService.java
@@ -1,0 +1,191 @@
+package com.doLink_server.domain.collection.service;
+
+import com.doLink_server.auth.service.AuthService;
+import com.doLink_server.domain.collection.dto.CollectionCreateRequest;
+import com.doLink_server.domain.collection.dto.CollectionResponse;
+import com.doLink_server.domain.collection.dto.CollectionSimpleResponse;
+import com.doLink_server.domain.collection.dto.CollectionUpdateRequest;
+import com.doLink_server.domain.collection.entity.Collection;
+import com.doLink_server.domain.collection.repository.CollectionRepository;
+
+
+import com.doLink_server.global.common.status.ErrorStatus;
+import com.doLink_server.global.enums.Category;
+import com.doLink_server.global.exception.GeneralException;
+import com.doLink_server.user.entity.Users;
+import com.doLink_server.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 모음 서비스
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CollectionService {
+
+    private final CollectionRepository collectionRepository;
+    private final AuthService authService;     // 로그인 유저 조회
+    private final UserService userService;
+
+    /**
+     * 모음 전체 조회 (Slice + 최신 생성 순)
+     */
+    public Slice<CollectionResponse> listAllSlice(int page, int size) {
+
+        Users user = getLoginUser();
+        PageRequest pageable = PageRequest.of(page, size);
+
+        return collectionRepository
+                .findAllByUserOrderByCreatedAtDesc(user, pageable)
+                .map(this::toResponse);
+    }
+
+    /**
+     * 카테고리별 모음 조회 (Slice + 최신 생성 순)
+     */
+    public Slice<CollectionResponse> listByCategorySlice(
+            Category category,
+            int page,
+            int size
+    ) {
+        Users user = getLoginUser();
+        PageRequest pageable = PageRequest.of(page, size);
+
+        return collectionRepository
+                .findAllByUserAndCategoryOrderByCreatedAtDesc(user, category, pageable)
+                .map(this::toResponse);
+    }
+
+    private Users getLoginUser() {
+        String currentUserId = authService.getAuthenticatedUserId();
+        return userService.findExistingUser(currentUserId);
+    }
+
+    private CollectionResponse toResponse(Collection c) {
+        return CollectionResponse.builder()
+                .collectionId(c.getCollectionId())
+                .name(c.getName())
+                .category(c.getCategory())
+                .thumbnails(List.of()) // TODO: 썸네일 추후 추가
+                .build();
+    }
+
+    /**
+     * 모음 생성
+     */
+    @Transactional
+    public CollectionResponse createCollect(CollectionCreateRequest request) {
+
+        // 1) 유저 조회
+        String currentUserId = authService.getAuthenticatedUserId(); // 인증객체에서 사용자 아이디(UUID 문자열) 가져오기
+        Users user = userService.findExistingUser(currentUserId); // 유저 존재 검증 (없으면 예외)
+
+        Collection saved = collectionRepository.save(
+                Collection.builder()
+                        .user(user)
+                        .name(request.name())
+                        .category(request.category())
+                        .build()
+        );
+
+        return CollectionResponse.builder()
+                .collectionId(saved.getCollectionId()) // 모음 ID
+                .name(saved.getName())                 // 모음 이름
+                .category(saved.getCategory())         // 모음 카테고리
+                .thumbnails(List.of())                 // 썸네일 목록(할 일 기능 이후 채움)
+                .build();
+    }
+
+    /**
+     * 모음 삭제
+     * - 로그인 사용자의 모음만 삭제 가능
+     * - (DB FK ON DELETE CASCADE 설정 시) 하위 Task도 함께 삭제됨
+     */
+    @Transactional
+    public void deleteCollect(Long collectionId) {
+
+        // 1) 유저 조회
+        String currentUserId = authService.getAuthenticatedUserId();
+        Users user = userService.findExistingUser(currentUserId);
+
+
+        // 2) 모음 조회 (User까지 fetch join) - 없으면 404
+        Collection collection = collectionRepository.findByIdWithUser(collectionId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_FOUND_COLLECTION));
+
+        // 3) 권한 확인 - 남의 모음이면 403
+        if (!collection.getUser().getUserId().equals(user.getUserId())) {
+            throw new GeneralException(ErrorStatus._FORBIDDEN_COLLECTION);
+        }
+
+        // 4) 삭제
+        // CASCADE라 하위 Task도 함께 삭제됨
+        collectionRepository.delete(collection);
+    }
+
+    /**
+     * 모음 수정
+     *
+     * - 로그인 사용자의 모음만 수정 가능
+     * - 수정 항목: name, category
+     *
+     * @param collectionId 수정할 모음 ID
+     * @param request      수정 요청(name, category)
+     * @return 수정된 모음 응답 DTO
+     */
+    @Transactional
+    public CollectionResponse updateCollect(Long collectionId, CollectionUpdateRequest request) {
+
+        // 1) 로그인 유저 조회
+        String currentUserId = authService.getAuthenticatedUserId();
+        Users user = userService.findExistingUser(currentUserId);
+
+        // 2) 모음 조회 + user fetch join (없으면 404)
+        Collection collection = collectionRepository.findByIdWithUser(collectionId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_FOUND_COLLECTION));
+
+        // 3) 권한 체크 (내 모음인지)
+        if (!collection.getUser().getUserId().equals(user.getUserId())) {
+            throw new GeneralException(ErrorStatus._FORBIDDEN_COLLECTION);
+        }
+
+        // 4) 수정 반영 (Dirty Checking)
+        collection.setName(request.name());
+        collection.setCategory(request.category());
+
+        // 5) 응답 변환
+        return CollectionResponse.builder()
+                .collectionId(collection.getCollectionId())
+                .name(collection.getName())
+                .category(collection.getCategory())
+                .thumbnails(List.of()) // TODO: Task 썸네일 완성되면 채우기
+                .build();
+    }
+
+    /**
+     * 할 일 추가 화면용 모음 선택 목록 조회
+     *
+     * - 로그인한 사용자가 보유한 모음 전체 조회
+     * 사용처: 할 일 추가 화면 > "담을 모음 선택"
+     */
+    @Transactional(readOnly = true)
+    public List<CollectionSimpleResponse> listCollectOptions() {
+        String currentUserId = authService.getAuthenticatedUserId();
+        Users user = userService.findExistingUser(currentUserId);
+
+        return collectionRepository.findAllByUser(user)
+                .stream()
+                .map(c -> CollectionSimpleResponse.builder()
+                        .collectionId(c.getCollectionId())
+                        .name(c.getName())
+                        .build())
+                .toList();
+    }
+}

--- a/src/main/java/com/doLink_server/domain/task/controller/TaskController.java
+++ b/src/main/java/com/doLink_server/domain/task/controller/TaskController.java
@@ -1,0 +1,47 @@
+package com.doLink_server.domain.task.controller;
+
+import com.doLink_server.domain.task.dto.TaskCreateRequest;
+import com.doLink_server.domain.task.dto.TaskResponse;
+import com.doLink_server.domain.task.service.TaskService;
+import com.doLink_server.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/task")
+@Tag(name = "Task", description = "할 일 관련 API")
+public class TaskController {
+
+    private final TaskService taskService;
+
+    /**
+     * 할 일 추가
+     */
+    @PostMapping
+    @Operation(summary = "할 일 추가", description = "할 일을 생성한다.")
+    public ApiResponse<TaskResponse> create(@Valid @RequestBody TaskCreateRequest request) {
+        return ApiResponse.onSuccess(taskService.taskCreate(request));
+    }
+
+    /**
+     * 모음별 Task 전체 조회, 페이지네이션으로 마이그레이션 필요!!
+     */
+    @GetMapping("/collections/{collectionId}")
+    @Operation(summary = "모음별 Task 전체 조회", description = "collectionId에 속한 Task를 전부 조회한다.")
+    public ApiResponse<List<TaskResponse>> listByCollection(@PathVariable Long collectionId) {
+        return ApiResponse.onSuccess(taskService.listByCollection(collectionId));
+    }
+
+
+
+
+
+
+
+}

--- a/src/main/java/com/doLink_server/domain/task/dto/TaskCreateRequest.java
+++ b/src/main/java/com/doLink_server/domain/task/dto/TaskCreateRequest.java
@@ -1,0 +1,21 @@
+package com.doLink_server.domain.task.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record TaskCreateRequest(
+
+        /** 모음 ID */
+        @NotNull(message = "컬렉션 ID는 필수입니다.")
+        Long collectionId,
+
+        /** 할 일 제목 */
+        @NotBlank(message = "제목은 필수입니다.")
+        @Size(max = 100, message = "제목은 최대 100자까지 가능합니다.")
+        String title,
+
+        String link,
+        String memo
+) {
+}

--- a/src/main/java/com/doLink_server/domain/task/dto/TaskResponse.java
+++ b/src/main/java/com/doLink_server/domain/task/dto/TaskResponse.java
@@ -1,0 +1,15 @@
+package com.doLink_server.domain.task.dto;
+
+import lombok.Builder;
+
+@Builder
+public record TaskResponse(
+        Long taskId,
+        Long collectionId,
+        String title,
+        String link,
+        String memo,
+        Boolean status,
+        Boolean inout
+) {
+}

--- a/src/main/java/com/doLink_server/domain/task/entity/Task.java
+++ b/src/main/java/com/doLink_server/domain/task/entity/Task.java
@@ -1,0 +1,81 @@
+package com.doLink_server.domain.task.entity;
+
+import com.doLink_server.domain.collection.entity.Collection;
+import com.doLink_server.global.common.BaseEntity;
+import com.doLink_server.user.entity.Users;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+/**
+ * 할 일(Task) 테이블
+ */
+@Getter
+@Setter
+@Entity
+@Builder
+@Table(name = "task", schema = "dolink")
+@NoArgsConstructor
+@AllArgsConstructor
+public class Task extends BaseEntity {
+
+    /**
+     * 할 일 ID (AUTO INCREMENT)
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "task_id")
+    private Long taskId;
+
+    /**
+     * 사용자 (Users 1 : Task N)
+     */
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "user_id", nullable = false, columnDefinition = "BINARY(16)")
+    private Users user;
+
+    /**
+     * 모음 (Collection 1 : Task N)
+     * - 모음 삭제 시 할 일도 같이 삭제되길 원하면 CASCADE
+     */
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "collection_id", nullable = false)
+    private Collection collection;
+
+    /**
+     * 제목
+     */
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    /**
+     * 링크
+     */
+    @Column(name = "link")
+    private String link;
+
+    /**
+     * 메모
+     */
+    @Column(name = "memo")
+    private String memo;
+
+    /**
+     * 상태 (완료 여부)
+     */
+    @Column(name = "status")
+    private Boolean status;
+
+    /**
+     * 내부: true
+     * 외부: false
+     */
+    @Column(name = "in_out")
+    private Boolean inout;
+}

--- a/src/main/java/com/doLink_server/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/doLink_server/domain/task/repository/TaskRepository.java
@@ -1,0 +1,15 @@
+package com.doLink_server.domain.task.repository;
+
+import com.doLink_server.domain.task.entity.Task;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TaskRepository extends JpaRepository<Task, Long> {
+
+    /**
+     * 모음별 Task 전체 조회
+     */
+    List<Task> findAllByCollection_CollectionIdOrderByTaskIdDesc(Long collectionId);
+
+}

--- a/src/main/java/com/doLink_server/domain/task/service/TaskService.java
+++ b/src/main/java/com/doLink_server/domain/task/service/TaskService.java
@@ -42,11 +42,11 @@ public class TaskService {
         Collection collection = collectionRepository.findByIdWithUser(request.collectionId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_FOUND_COLLECTION));
 
-        // 3) 권한 확인
-        if (!collection.getUser().getUserId().equals(user.getUserId())) {
+        // 3) 권한 확인 (내 모음인지) (403)
+        if (!Arrays.equals(collection.getUser().getUserId(), user.getUserId())) {
             throw new GeneralException(ErrorStatus._UNAUTHORIZED_TASK);
         }
-
+        
         // 4) Task 저장
         Task saved = taskRepository.save(
                 Task.builder()
@@ -75,7 +75,7 @@ public class TaskService {
 
         // 2) 모음 조회 (없으면 404)
         Collection collection = collectionRepository.findByIdWithUser(collectionId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_FOUND_TASK));
+                .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_FOUND_COLLECTION));
 
         // 3) 권한 확인 (내 모음인지) (403)
         if (!Arrays.equals(collection.getUser().getUserId(), user.getUserId())) {

--- a/src/main/java/com/doLink_server/domain/task/service/TaskService.java
+++ b/src/main/java/com/doLink_server/domain/task/service/TaskService.java
@@ -1,0 +1,103 @@
+package com.doLink_server.domain.task.service;
+
+import com.doLink_server.auth.service.AuthService;
+import com.doLink_server.domain.collection.entity.Collection;
+import com.doLink_server.domain.collection.repository.CollectionRepository;
+import com.doLink_server.domain.task.dto.TaskCreateRequest;
+import com.doLink_server.domain.task.dto.TaskResponse;
+import com.doLink_server.domain.task.entity.Task;
+import com.doLink_server.domain.task.repository.TaskRepository;
+import com.doLink_server.global.common.status.ErrorStatus;
+import com.doLink_server.global.exception.GeneralException;
+import com.doLink_server.user.entity.Users;
+import com.doLink_server.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TaskService {
+
+    private final TaskRepository taskRepository;
+    private final CollectionRepository collectionRepository;
+    private final AuthService authService;
+    private final UserService userService;
+
+    /**
+     * 할 일 추가
+     */
+    @Transactional
+    public TaskResponse taskCreate(TaskCreateRequest request) {
+
+        // 1) 로그인 유저 조회
+        String currentUserId = authService.getAuthenticatedUserId();
+        Users user = userService.findExistingUser(currentUserId);
+
+        // 2) 모음 조회
+        Collection collection = collectionRepository.findByIdWithUser(request.collectionId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_FOUND_COLLECTION));
+
+        // 3) 권한 확인
+        if (!collection.getUser().getUserId().equals(user.getUserId())) {
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED_TASK);
+        }
+
+        // 4) Task 저장
+        Task saved = taskRepository.save(
+                Task.builder()
+                        .user(user)
+                        .collection(collection)
+                        .title(request.title())
+                        .link(request.link())
+                        .memo(request.memo())
+                        .inout(true) // 내부추가는 true
+                        .status(false) // 할 일 false 시작
+                        .build()
+        );
+
+        // 4) 응답
+        return toResponse(saved);
+    }
+
+    /**
+     * 모음별 Task 전체 조회
+     */
+    public List<TaskResponse> listByCollection(Long collectionId) {
+
+        // 1) 유저 조회
+        String currentUserId = authService.getAuthenticatedUserId();
+        Users user = userService.findExistingUser(currentUserId);
+
+        // 2) 모음 조회 (없으면 404)
+        Collection collection = collectionRepository.findByIdWithUser(collectionId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_FOUND_TASK));
+
+        // 3) 권한 확인 (내 모음인지) (403)
+        if (!Arrays.equals(collection.getUser().getUserId(), user.getUserId())) {
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED_TASK);
+        }
+
+        // 4) 해당 모음의 Task 전체 조회
+        return taskRepository.findAllByCollection_CollectionIdOrderByTaskIdDesc(collectionId)
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    private TaskResponse toResponse(Task t) {
+        return TaskResponse.builder()
+                .taskId(t.getTaskId())
+                .collectionId(t.getCollection().getCollectionId())
+                .title(t.getTitle())
+                .link(t.getLink())
+                .memo(t.getMemo())
+                .status(t.getStatus())
+                .inout(t.getInout())
+                .build();
+    }
+}

--- a/src/main/java/com/doLink_server/global/common/status/ErrorStatus.java
+++ b/src/main/java/com/doLink_server/global/common/status/ErrorStatus.java
@@ -34,19 +34,26 @@ public enum ErrorStatus implements BaseErrorCode {
     _NOT_IMPLEMENTED_SOCIAL(HttpStatus.NOT_IMPLEMENTED, "SOCIAL501", "해당 소셜 플랫폼의 해제 기능은 아직 구현되지 않았습니다."),
     _KAKAO_UNLINK_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SOCIAL502", "카카오 관리자 인증 해제에 실패했습니다."),
 
-    // Task 에러
+    // 두링크_collection 에러
+    _INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "COLL400", "유효하지 않은 모음 카테고리입니다."),
+    _NOT_FOUND_COLLECTION(HttpStatus.NOT_FOUND, "COLL404", "모음이 존재하지 않습니다."),
+    _FORBIDDEN_COLLECTION(HttpStatus.FORBIDDEN, "COLL403", "모음에 대한 접근 권한이 없습니다."),
+
+    // 두링크_Task 에러
     _NOT_FOUND_TASK(HttpStatus.NOT_FOUND, "TASK404", "할 일이 존재하지 않습니다."),
-    _UNAUTHORIZED_ACCESS_TASK(HttpStatus.FORBIDDEN, "TASK403", "할 일 권한이 없습니다."),
+    _UNAUTHORIZED_TASK(HttpStatus.FORBIDDEN, "TASK403", "할 일 권한이 없습니다."),
+
+    // 톡투두_Task 에러
     _INVALID_PRIORITY(HttpStatus.BAD_REQUEST, "TASK400", "잘못된 우선순위입니다."),
     _INVALID_REPEAT_CONFIGURATION(HttpStatus.BAD_REQUEST, "TASK410", "잘못된 반복 설정입니다."),
 
-    // Memo 에러
+    // 톡투두_Memo 에러
     _NOT_FOUND_MEMO(HttpStatus.NOT_FOUND, "MEMO404", "메모가 존재하지 않습니다."),
 
-    // Goal 에러
+    // 톡투두_Goal 에러
     _NOT_FOUND_GOAL(HttpStatus.NOT_FOUND, "GOAL404", "목표가 존재하지 않습니다."),
 
-    // Security 에러
+    // 톡투두_Security 에러
     NEED_LOGIN(HttpStatus.NOT_FOUND, "SEC1001", "로그인 후 사용해주세요."),
     ALREADY_LOGOUT(HttpStatus.UNAUTHORIZED, "SEC1002", "이미 로그아웃 된 사용자입니다."),
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "SEC4001", "잘못된 형식의 토큰입니다."),

--- a/src/main/java/com/doLink_server/global/config/WebConfig.java
+++ b/src/main/java/com/doLink_server/global/config/WebConfig.java
@@ -1,0 +1,36 @@
+package com.doLink_server.global.config;
+
+import com.doLink_server.global.converter.StringToCategoryConverter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Web MVC 전역 설정 클래스
+ *
+ * - Spring MVC에서 사용할 Converter / Formatter를 전역으로 등록
+ * - Controller의 @RequestParam, @PathVariable 바인딩 시 자동 적용
+ *
+ * 현재 역할:
+ * - String → Category enum 변환 Converter 등록
+ *   (예: "FOOD", "food", "맛집" → Category.FOOD)
+ */
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+    private final StringToCategoryConverter stringToCategoryConverter;
+
+    /**
+     * Spring MVC에서 사용할 Formatter / Converter 등록
+     *
+     * - @RequestParam Category category
+     * - @PathVariable Category category
+     *
+     * 와 같은 경우에 자동으로 StringToCategoryConverter가 적용됨
+     */
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(stringToCategoryConverter);
+    }
+}

--- a/src/main/java/com/doLink_server/global/converter/StringToCategoryConverter.java
+++ b/src/main/java/com/doLink_server/global/converter/StringToCategoryConverter.java
@@ -1,0 +1,41 @@
+package com.doLink_server.global.converter;
+
+import com.doLink_server.global.enums.Category;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+/**
+ * String → Category enum 변환 Converter
+ *
+ * 사용 목적:
+ * - @RequestParam / @PathVariable 로 들어오는 문자열을
+ *   Category enum으로 안전하게 변환하기 위함
+ *
+ * 지원 예시:
+ * - "FOOD"
+ * - "food"
+ * - "맛집"
+ *
+ * → 모두 Category.FOOD 로 변환
+ *
+ * 적용 범위:
+ * - Controller의 @RequestParam Category
+ * - Controller의 @PathVariable Category
+ */
+@Component
+public class StringToCategoryConverter implements Converter<String, Category> {
+
+
+    /**
+     * 문자열 값을 Category enum으로 변환
+     *
+     * @param source 요청 파라미터로 전달된 문자열
+     * @return 변환된 Category enum
+     */
+    @Override
+    public Category convert(String source) {
+        return Category.from(source); // - 영어(enum name) / 한글(label) 모두 허용
+    }
+
+}

--- a/src/main/java/com/doLink_server/global/enums/Category.java
+++ b/src/main/java/com/doLink_server/global/enums/Category.java
@@ -1,0 +1,64 @@
+package com.doLink_server.global.enums;
+
+import com.doLink_server.global.common.status.ErrorStatus;
+import com.doLink_server.global.exception.GeneralException;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum Category {
+
+    FOOD("맛집"),
+    HOBBY("취미"),
+    TRAVEL("여행"),
+    FINANCE("재테크"),
+    SHOPPING("쇼핑"),
+    WORKOUT("운동"),
+    CAREER("커리어"),
+    SELF_DEV("자기개발"),
+    LIFE_HACK("꿀팁"),
+    ETC("기타");
+
+    private final String labelKorean;
+
+    Category(String labelKorean) {
+        this.labelKorean = labelKorean;
+    }
+
+    /** API 응답 시 내려보낼 한글 라벨 */
+    @JsonValue
+    public String getLabelKorean() {
+        return labelKorean;
+    }
+
+    private static final Map<String, Category> lookup = new HashMap<>();
+
+    static {
+        for (Category c : values()) {
+            lookup.put(c.name().toLowerCase(), c);   // "food"
+            lookup.put(c.labelKorean, c);            // "맛집"
+        }
+    }
+
+    /** 요청(JSON)으로 들어온 값(한글 or 영어) → Enum 변환 */
+    @JsonCreator
+    public static Category from(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new GeneralException(ErrorStatus._INVALID_CATEGORY);
+        }
+
+        Category c = lookup.get(value.trim().toLowerCase());
+        if (c != null) return c;
+
+        // 혹시 모를 한글 직접 비교 fallback
+        String trimmed = value.trim();
+        for (Category category : values()) {
+            if (category.labelKorean.equalsIgnoreCase(trimmed)) return category;
+        }
+
+        throw new GeneralException(ErrorStatus._INVALID_CATEGORY);
+    }
+
+}

--- a/src/main/java/com/doLink_server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/doLink_server/global/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 /**
  * 공통 예외 핸들러
@@ -16,6 +17,17 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Hidden
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentTypeMismatch(
+            MethodArgumentTypeMismatchException e
+    ) {
+        ApiResponse<Void> response = ApiResponse.onFailure(
+                ErrorStatus._BAD_REQUEST.getCode(),
+                "잘못된 요청 파라미터입니다."
+        );
+        return ResponseEntity.badRequest().body(response);
+    }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiResponse<Void>> handleIllegalArgumentException(IllegalArgumentException e) {

--- a/src/main/java/com/doLink_server/user/entity/Users.java
+++ b/src/main/java/com/doLink_server/user/entity/Users.java
@@ -19,7 +19,7 @@ import java.util.UUID;
 @Setter
 @Entity
 @Builder
-@Table(name = "users", schema = "talktodo")
+@Table(name = "users", schema = "dolink")
 @NoArgsConstructor
 @AllArgsConstructor
 public class Users extends BaseEntity {

--- a/src/main/resources/db/migration/V1__add_collection_indexes.sql
+++ b/src/main/resources/db/migration/V1__add_collection_indexes.sql
@@ -1,0 +1,7 @@
+-- 전체 모음 조회용 인덱스
+CREATE INDEX idx_collection_user_created_at
+    ON collection (user_id, created_at);
+
+-- 카테고리별 모음 조회용 인덱스
+CREATE INDEX idx_collection_user_category_created_at
+    ON collection (user_id, category, created_at);


### PR DESCRIPTION
## 🔢 Issue Number
- #9 

## 🎯 기능 개요
- **목적**: 모음(Collection) 기능 도입하고, 할 일(Task)의 최소 생성/조회 흐름
- **예시**: 
- 모음 CRUD API 추가
- 모음 조회(전체/카테고리) Slice 기반 무한스크롤 지원
- Task 생성 및 모음별 Task 조회 API 추가
- Category 요청 값 한글/영문 모두 역직렬화/변환 지원
- Validation / Flyway 도입 및 조회 성능용 인덱스 추가

## 🏗 구현 상세 및 설계 문서
✅ API 추가
### Collection
POST /api/v1/collect : 모음 생성
PATCH /api/v1/collect/{collectId} : 모음 수정(이름/카테고리)
DELETE /api/v1/collect/{collectId} : 모음 삭제
GET /api/v1/collect/all?page=&size= : 모음 전체 조회(Slice)
GET /api/v1/collect/category?category=&page=&size= : 카테고리별 조회(Slice)
GET /api/v1/collect/select : 할 일 추가 화면용 모음 선택 목록(id, name)

### Task
POST /api/v1/task : 할 일 생성(모음 소속)
GET /api/v1/task/collections/{collectionId} : 모음별 Task 전체 조회 (※ 추후 페이지네이션 전환 예정)
<img width="956" height="626" alt="image" src="https://github.com/user-attachments/assets/3901bd26-5659-4868-bce2-f4a701bd9ef9" />


## 💌 To Reviewers
- Category 변환(한글/영문) 로직이 JSON 바디(@JsonCreator) 와 RequestParam Converter 두 축으로 동작합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 컬렉션(모음) CRUD 및 목록 조회(전체/카테고리별, 선택용 간단 목록) 추가
  * 컬렉션 내 할 일 생성 및 컬렉션별 할 일 조회 추가
  * 카테고리 입력에 영어/한국어 모두 허용하는 유연한 처리 추가

* **버그 수정 / 개선**
  * 요청 파라미터 타입 오류에 대한 명확한 400 응답 처리 추가
  * 카테고리 관련 유효성 오류 메시지 개선

* **Chores**
  * DB 인덱스 및 마이그레이션 추가로 조회 성능 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->