### PR TITLE
모음 썸네일(OG) 저장/조회 + 리스트 성능 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,12 @@ dependencies {
 
 	// 외부 API 인터페이스
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	// AWS:S3
+	implementation 'org.jsoup:jsoup:1.17.2' // HTML 문서에서 og:title, og:image 등 OG 메타 태그를 파싱하기 위한 라이브러리
+	implementation platform('software.amazon.awssdk:bom:2.25.0') // AWS SDK v2
+	implementation 'software.amazon.awssdk:s3' // S3 객체 업로드/다운로드를 위한 클라이언트
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,11 @@ dependencies {
 	implementation platform('software.amazon.awssdk:bom:2.25.0') // AWS SDK v2
 	implementation 'software.amazon.awssdk:s3' // S3 객체 업로드/다운로드를 위한 클라이언트
 
+	// OG 메타데이터 분석 & 파싱 구현
+	implementation 'org.jsoup:jsoup:1.17.2' // OG
+	implementation 'net.coobird:thumbnailator:0.4.20' // 썸네일
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/doLink_server/domain/collection/repository/CollectionRepository.java
+++ b/src/main/java/com/doLink_server/domain/collection/repository/CollectionRepository.java
@@ -3,7 +3,6 @@ package com.doLink_server.domain.collection.repository;
 import com.doLink_server.domain.collection.entity.Collection;
 import com.doLink_server.global.enums.Category;
 import com.doLink_server.user.entity.Users;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/doLink_server/domain/collection/service/CollectionService.java
+++ b/src/main/java/com/doLink_server/domain/collection/service/CollectionService.java
@@ -9,18 +9,24 @@ import com.doLink_server.domain.collection.entity.Collection;
 import com.doLink_server.domain.collection.repository.CollectionRepository;
 
 
+import com.doLink_server.domain.task.repository.CollectionThumbnailRow;
+import com.doLink_server.domain.task.repository.TaskRepository;
 import com.doLink_server.global.common.status.ErrorStatus;
 import com.doLink_server.global.enums.Category;
 import com.doLink_server.global.exception.GeneralException;
+import com.doLink_server.infra.s3.S3PresignedUrlProvider;
 import com.doLink_server.user.entity.Users;
 import com.doLink_server.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * 모음 서비스
@@ -31,50 +37,126 @@ import java.util.List;
 public class CollectionService {
 
     private final CollectionRepository collectionRepository;
+    private final TaskRepository taskRepository;
+    private final S3PresignedUrlProvider presignedUrlProvider;
     private final AuthService authService;     // 로그인 유저 조회
     private final UserService userService;
 
     /**
-     * 모음 전체 조회 (Slice + 최신 생성 순)
+     * 모음 전체 조회 (Slice + 최신 생성 순) + 썸네일(최대 4개) 포함
      */
     public Slice<CollectionResponse> listAllSlice(int page, int size) {
 
         Users user = getLoginUser();
         PageRequest pageable = PageRequest.of(page, size);
 
-        return collectionRepository
-                .findAllByUserOrderByCreatedAtDesc(user, pageable)
-                .map(this::toResponse);
+        Slice<Collection> slice =
+                collectionRepository.findAllByUserOrderByCreatedAtDesc(user, pageable);
+
+        List<Collection> collections = slice.getContent();
+        if (collections.isEmpty()) {
+            return new SliceImpl<>(List.of(), pageable, slice.hasNext());
+        }
+
+        // 1) 모음 ID 수집
+        List<Long> collectionIds = collections.stream()
+                .map(Collection::getCollectionId)
+                .toList();
+
+        // 2) 모음별 썸네일 key를 한 번에 조회 (모음당 최대 4개)
+        List<CollectionThumbnailRow> rows =
+                taskRepository.findTop4ThumbnailsByCollectionIds(collectionIds);
+
+        // 3) collectionId -> thumbnailKey 리스트로 그룹핑
+        Map<Long, List<String>> thumbKeyMap = rows.stream()
+                .collect(Collectors.groupingBy(
+                        CollectionThumbnailRow::getCollectionId,
+                        Collectors.mapping(
+                                CollectionThumbnailRow::getThumbnailKey,
+                                Collectors.toList()
+                        )
+                ));
+
+        // 4) presigned URL 변환 + DTO 생성
+        List<CollectionResponse> responses = collections.stream()
+                .map(c -> {
+                    List<String> thumbnailUrls = thumbKeyMap
+                            .getOrDefault(c.getCollectionId(), List.of())
+                            .stream()
+                            .map(presignedUrlProvider::presignGetUrl)
+                            .toList();
+
+                    return CollectionResponse.builder()
+                            .collectionId(c.getCollectionId())
+                            .name(c.getName())
+                            .category(c.getCategory())
+                            .thumbnails(thumbnailUrls)
+                            .build();
+                })
+                .toList();
+
+        return new SliceImpl<>(responses, pageable, slice.hasNext());
     }
 
     /**
-     * 카테고리별 모음 조회 (Slice + 최신 생성 순)
+     * 카테고리별 모음 조회 (Slice + 최신 생성 순) + 썸네일(최대 4개) 포함
      */
-    public Slice<CollectionResponse> listByCategorySlice(
-            Category category,
-            int page,
-            int size
-    ) {
+    public Slice<CollectionResponse> listByCategorySlice(Category category, int page, int size) {
+
         Users user = getLoginUser();
         PageRequest pageable = PageRequest.of(page, size);
 
-        return collectionRepository
-                .findAllByUserAndCategoryOrderByCreatedAtDesc(user, category, pageable)
-                .map(this::toResponse);
+        Slice<Collection> slice =
+                collectionRepository.findAllByUserAndCategoryOrderByCreatedAtDesc(user, category, pageable);
+
+        List<Collection> collections = slice.getContent();
+        if (collections.isEmpty()) {
+            return new SliceImpl<>(List.of(), pageable, slice.hasNext());
+        }
+
+        // 1) 모음 ID 수집
+        List<Long> collectionIds = collections.stream()
+                .map(Collection::getCollectionId)
+                .toList();
+
+        // 2) 모음별 썸네일 key를 한 번에 조회 (모음당 최대 4개)
+        List<CollectionThumbnailRow> rows =
+                taskRepository.findTop4ThumbnailsByCollectionIds(collectionIds);
+
+        // 3) collectionId -> thumbnailKey 리스트로 그룹핑
+        Map<Long, List<String>> thumbKeyMap = rows.stream()
+                .collect(Collectors.groupingBy(
+                        CollectionThumbnailRow::getCollectionId,
+                        Collectors.mapping(
+                                CollectionThumbnailRow::getThumbnailKey,
+                                Collectors.toList()
+                        )
+                ));
+
+        // 4) presigned URL 변환 + DTO 생성
+        List<CollectionResponse> responses = collections.stream()
+                .map(c -> {
+                    List<String> thumbnailUrls = thumbKeyMap
+                            .getOrDefault(c.getCollectionId(), List.of())
+                            .stream()
+                            .map(presignedUrlProvider::presignGetUrl)
+                            .toList();
+
+                    return CollectionResponse.builder()
+                            .collectionId(c.getCollectionId())
+                            .name(c.getName())
+                            .category(c.getCategory())
+                            .thumbnails(thumbnailUrls)
+                            .build();
+                })
+                .toList();
+
+        return new SliceImpl<>(responses, pageable, slice.hasNext());
     }
 
     private Users getLoginUser() {
         String currentUserId = authService.getAuthenticatedUserId();
         return userService.findExistingUser(currentUserId);
-    }
-
-    private CollectionResponse toResponse(Collection c) {
-        return CollectionResponse.builder()
-                .collectionId(c.getCollectionId())
-                .name(c.getName())
-                .category(c.getCategory())
-                .thumbnails(List.of()) // TODO: 썸네일 추후 추가
-                .build();
     }
 
     /**

--- a/src/main/java/com/doLink_server/domain/task/controller/LinkController.java
+++ b/src/main/java/com/doLink_server/domain/task/controller/LinkController.java
@@ -1,0 +1,42 @@
+package com.doLink_server.domain.task.controller;
+
+import com.doLink_server.domain.task.dto.LinkCreateResult;
+import com.doLink_server.domain.task.service.LinkCreateService;
+import com.doLink_server.global.common.ApiResponse;
+import com.doLink_server.infra.og.dto.LinkPreviewRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * (S3+OG 메타데이터) 임시 확인용 컨트롤러
+ * prod 에서 삭제
+ */
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/link")
+@Tag(name = "Link", description = "링크 미리보기(OG) API")
+public class LinkController {
+
+    private final LinkCreateService linkCreateService;
+
+    /**
+     * 링크 미리보기 (OG 파싱 + S3 업로드 테스트용)
+     */
+    @PostMapping("/preview")
+    @Operation(summary = "링크 미리보기", description = "OG 파싱 및 썸네일 S3 업로드 결과를 반환한다.")
+    public ApiResponse<LinkCreateResult> preview(
+            @Valid @RequestBody LinkPreviewRequest request
+    ) {
+        return ApiResponse.onSuccess(
+                linkCreateService.create(request.url())
+        );
+    }
+
+}

--- a/src/main/java/com/doLink_server/domain/task/dto/LinkCreateResult.java
+++ b/src/main/java/com/doLink_server/domain/task/dto/LinkCreateResult.java
@@ -1,0 +1,15 @@
+package com.doLink_server.domain.task.dto;
+
+/**
+ * - 링크 생성 결과 DTO
+ * - S3 key(저장용)와 presigned URL(표시용)을 함께 반환
+ */
+public record LinkCreateResult(
+        String title,
+        String description,
+        String siteName,
+        String canonicalUrl,
+        String thumbnailKey,
+        String thumbnailUrl
+) {
+}

--- a/src/main/java/com/doLink_server/domain/task/dto/LinkCreateResult.java
+++ b/src/main/java/com/doLink_server/domain/task/dto/LinkCreateResult.java
@@ -9,7 +9,9 @@ public record LinkCreateResult(
         String description,
         String siteName,
         String canonicalUrl,
+        String originalKey,
+        String originalUrl,
         String thumbnailKey,
         String thumbnailUrl
-) {
-}
+) {}
+

--- a/src/main/java/com/doLink_server/domain/task/entity/Task.java
+++ b/src/main/java/com/doLink_server/domain/task/entity/Task.java
@@ -68,6 +68,14 @@ public class Task extends BaseEntity {
     private String thumbnailKey;
 
     /**
+     * OG 원본 이미지 S3 key
+     * - DB에는 URL이 아니라 key만 저장
+     */
+    @Column(name = "og_image_key", length = 500)
+    private String ogImageKey;
+
+
+    /**
      * 메모
      */
     @Column(name = "memo")

--- a/src/main/java/com/doLink_server/domain/task/entity/Task.java
+++ b/src/main/java/com/doLink_server/domain/task/entity/Task.java
@@ -61,6 +61,13 @@ public class Task extends BaseEntity {
     private String link;
 
     /**
+     * OG 대표 썸네일 S3 key
+     * - DB에는 URL이 아니라 key만 저장 (presigned는 조회 시 생성)
+     */
+    @Column(name = "thumbnail_key", length = 500)
+    private String thumbnailKey;
+
+    /**
      * 메모
      */
     @Column(name = "memo")

--- a/src/main/java/com/doLink_server/domain/task/repository/CollectionThumbnailRow.java
+++ b/src/main/java/com/doLink_server/domain/task/repository/CollectionThumbnailRow.java
@@ -1,0 +1,10 @@
+package com.doLink_server.domain.task.repository;
+
+/**
+ * 모음 썸네일 조회용 Projection
+ * - collectionId + thumbnailKey만 가져온다.
+ */
+public interface CollectionThumbnailRow {
+    Long getCollectionId();
+    String getThumbnailKey();
+}

--- a/src/main/java/com/doLink_server/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/doLink_server/domain/task/repository/TaskRepository.java
@@ -1,9 +1,10 @@
 package com.doLink_server.domain.task.repository;
 
 import com.doLink_server.domain.task.entity.Task;
-import io.lettuce.core.dynamic.annotation.Param;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 

--- a/src/main/java/com/doLink_server/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/doLink_server/domain/task/repository/TaskRepository.java
@@ -1,7 +1,9 @@
 package com.doLink_server.domain.task.repository;
 
 import com.doLink_server.domain.task.entity.Task;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -12,4 +14,28 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
      */
     List<Task> findAllByCollection_CollectionIdOrderByTaskIdDesc(Long collectionId);
 
+    /**
+     * 여러 모음에 대해 모음별 대표 썸네일 최대 4개를 한 번에 조회
+     * - 최신 Task(created_at DESC) 기준
+     * - thumbnail_key 있는 Task만 대상으로 함
+     */
+    @Query(value = """
+        SELECT collection_id AS collectionId, thumbnail_key AS thumbnailKey
+        FROM (
+            SELECT
+                t.collection_id,
+                t.thumbnail_key,
+                ROW_NUMBER() OVER (
+                    PARTITION BY t.collection_id
+                    ORDER BY t.created_at DESC
+                ) rn
+            FROM dolink.task t
+            WHERE t.collection_id IN (:collectionIds)
+              AND t.thumbnail_key IS NOT NULL
+        ) x
+        WHERE rn <= 4
+        """, nativeQuery = true)
+    List<CollectionThumbnailRow> findTop4ThumbnailsByCollectionIds(
+            @Param("collectionIds") List<Long> collectionIds
+    );
 }

--- a/src/main/java/com/doLink_server/domain/task/service/LinkCreateService.java
+++ b/src/main/java/com/doLink_server/domain/task/service/LinkCreateService.java
@@ -1,0 +1,101 @@
+package com.doLink_server.domain.task.service;
+
+import com.doLink_server.domain.task.dto.LinkCreateResult;
+import com.doLink_server.infra.og.downloader.ImageDownloader;
+import com.doLink_server.infra.og.dto.OgMetadata;
+import com.doLink_server.infra.og.parser.OgMetadataParser;
+import com.doLink_server.infra.og.resizer.OgThumbnailResizer;
+import com.doLink_server.infra.s3.OgThumbnailKeyGenerator;
+import com.doLink_server.infra.s3.S3PresignedUrlProvider;
+import com.doLink_server.infra.s3.S3Uploader;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 링크 생성 시 OG 메타데이터를 파싱하고
+ * 대표 썸네일을 생성하여 S3에 저장하는 서비스
+ *
+ * - 썸네일: 256x256 cover crop + webp(quality 0.85)
+ * - DB에는 S3 key 저장
+ * - 응답에는 presigned URL 포함
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LinkCreateService {
+
+    private final OgMetadataParser ogParser;
+    private final ImageDownloader imageDownloader;
+    private final OgThumbnailResizer thumbnailResizer;
+    private final OgThumbnailKeyGenerator keyGenerator;
+    private final S3Uploader s3Uploader;
+    private final S3PresignedUrlProvider presignedUrlProvider;
+
+    @Transactional
+    public LinkCreateResult create(String url) {
+        try {
+            // 1️⃣ OG 메타데이터 파싱
+            OgMetadata og = ogParser.parse(url);
+            log.info("[LinkCreate] og.imageUrl={}", og.imageUrl());
+
+            String thumbnailKey = null;
+            String thumbnailUrl = null;
+
+            // 2️⃣ OG 이미지가 있는 경우에만 처리
+            if (og.imageUrl() != null) {
+
+                ImageDownloader.DownloadedImage img =
+                        imageDownloader.download(og.imageUrl());
+
+                if (img == null) {
+                    log.warn("[LinkCreate] image download failed. url={}", og.imageUrl());
+                }
+
+                if (img != null && img.bytes() != null && img.bytes().length > 0) {
+
+                    // 3️⃣ 썸네일 리사이즈
+                    OgThumbnailResizer.ResizedImage thumb =
+                            thumbnailResizer.toSquarePng(img.bytes());
+
+                    if (thumb == null) {
+                        log.warn("[LinkCreate] thumbnail resize failed.");
+                    }
+
+                    if (thumb != null) {
+                        // 4️⃣ 썸네일 S3 key 생성
+                        String key = keyGenerator.generateThumbPng();
+
+                        // 5️⃣ S3 업로드
+                        thumbnailKey = s3Uploader.uploadPrivate(
+                                key,
+                                thumb.bytes(),
+                                thumb.contentType()
+                        );
+
+                        log.info("[LinkCreate] thumbnail uploaded. key={}", thumbnailKey);
+
+                        // 6️⃣ presigned URL 발급
+                        thumbnailUrl =
+                                presignedUrlProvider.presignGetUrl(thumbnailKey);
+                    }
+                }
+            }
+
+            // 7️⃣ 결과 반환
+            return new LinkCreateResult(
+                    og.title(),
+                    og.description(),
+                    og.siteName(),
+                    og.canonicalUrl(),
+                    thumbnailKey,
+                    thumbnailUrl
+            );
+
+        } catch (Exception e) {
+            log.error("[LinkCreate] failed. url={}", url, e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/doLink_server/domain/task/service/LinkCreateService.java
+++ b/src/main/java/com/doLink_server/domain/task/service/LinkCreateService.java
@@ -13,14 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * 링크 생성 시 OG 메타데이터를 파싱하고
- * 대표 썸네일을 생성하여 S3에 저장하는 서비스
- *
- * - 썸네일: 256x256 cover crop + webp(quality 0.85)
- * - DB에는 S3 key 저장
- * - 응답에는 presigned URL 포함
- */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -36,59 +28,49 @@ public class LinkCreateService {
     @Transactional
     public LinkCreateResult create(String url) {
         try {
-            // 1️⃣ OG 메타데이터 파싱
+            // 1) OG 메타 파싱
             OgMetadata og = ogParser.parse(url);
             log.info("[LinkCreate] og.imageUrl={}", og.imageUrl());
 
+            String originalKey = null;
+            String originalUrl = null;
             String thumbnailKey = null;
             String thumbnailUrl = null;
 
-            // 2️⃣ OG 이미지가 있는 경우에만 처리
+            // 2) OG 이미지 처리
             if (og.imageUrl() != null) {
+                ImageDownloader.DownloadedImage img = imageDownloader.download(og.imageUrl());
 
-                ImageDownloader.DownloadedImage img =
-                        imageDownloader.download(og.imageUrl());
+                if (img == null || img.bytes() == null || img.bytes().length == 0) {
+                    log.warn("[LinkCreate] image download failed or empty. url={}", og.imageUrl());
+                } else {
+                    // (A) 원본 업로드
+                    originalKey = keyGenerator.generateOriginal(img.contentType());
+                    originalKey = s3Uploader.uploadPrivate(originalKey, img.bytes(), img.contentType());
+                    originalUrl = presignedUrlProvider.presignGetUrl(originalKey);
 
-                if (img == null) {
-                    log.warn("[LinkCreate] image download failed. url={}", og.imageUrl());
-                }
-
-                if (img != null && img.bytes() != null && img.bytes().length > 0) {
-
-                    // 3️⃣ 썸네일 리사이즈
-                    OgThumbnailResizer.ResizedImage thumb =
-                            thumbnailResizer.toSquarePng(img.bytes());
-
-                    if (thumb == null) {
+                    // (B) 썸네일 생성 + 업로드
+                    OgThumbnailResizer.ResizedImage thumb = thumbnailResizer.toSquarePng(img.bytes());
+                    if (thumb == null || thumb.bytes() == null || thumb.bytes().length == 0) {
                         log.warn("[LinkCreate] thumbnail resize failed.");
-                    }
-
-                    if (thumb != null) {
-                        // 4️⃣ 썸네일 S3 key 생성
-                        String key = keyGenerator.generateThumbPng();
-
-                        // 5️⃣ S3 업로드
-                        thumbnailKey = s3Uploader.uploadPrivate(
-                                key,
-                                thumb.bytes(),
-                                thumb.contentType()
-                        );
+                    } else {
+                        thumbnailKey = keyGenerator.generateThumbPng();
+                        thumbnailKey = s3Uploader.uploadPrivate(thumbnailKey, thumb.bytes(), thumb.contentType());
+                        thumbnailUrl = presignedUrlProvider.presignGetUrl(thumbnailKey);
 
                         log.info("[LinkCreate] thumbnail uploaded. key={}", thumbnailKey);
-
-                        // 6️⃣ presigned URL 발급
-                        thumbnailUrl =
-                                presignedUrlProvider.presignGetUrl(thumbnailKey);
                     }
                 }
             }
 
-            // 7️⃣ 결과 반환
+            // 3) 결과 반환 (DB 저장에 필요한 key 포함)
             return new LinkCreateResult(
                     og.title(),
                     og.description(),
                     og.siteName(),
                     og.canonicalUrl(),
+                    originalKey,
+                    originalUrl,
                     thumbnailKey,
                     thumbnailUrl
             );

--- a/src/main/java/com/doLink_server/domain/task/service/TaskService.java
+++ b/src/main/java/com/doLink_server/domain/task/service/TaskService.java
@@ -50,12 +50,13 @@ public class TaskService {
         }
 
         // 4) 링크가 있으면 OG + 썸네일 처리
+        String ogImageKey = null;
         String thumbnailKey = null;
 
         if (request.link() != null && !request.link().isBlank()) {
-            LinkCreateResult linkResult =
-                    linkCreateService.create(request.link());
+            LinkCreateResult linkResult = linkCreateService.create(request.link());
 
+            ogImageKey = linkResult.originalKey();
             thumbnailKey = linkResult.thumbnailKey();
         }
 
@@ -67,7 +68,8 @@ public class TaskService {
                         .title(request.title())
                         .link(request.link())
                         .memo(request.memo())
-                        .thumbnailKey(thumbnailKey) 
+                        .ogImageKey(ogImageKey)
+                        .thumbnailKey(thumbnailKey)
                         .inout(true)
                         .status(false)
                         .build()

--- a/src/main/java/com/doLink_server/domain/task/service/TaskService.java
+++ b/src/main/java/com/doLink_server/domain/task/service/TaskService.java
@@ -3,6 +3,7 @@ package com.doLink_server.domain.task.service;
 import com.doLink_server.auth.service.AuthService;
 import com.doLink_server.domain.collection.entity.Collection;
 import com.doLink_server.domain.collection.repository.CollectionRepository;
+import com.doLink_server.domain.task.dto.LinkCreateResult;
 import com.doLink_server.domain.task.dto.TaskCreateRequest;
 import com.doLink_server.domain.task.dto.TaskResponse;
 import com.doLink_server.domain.task.entity.Task;
@@ -27,6 +28,7 @@ public class TaskService {
     private final CollectionRepository collectionRepository;
     private final AuthService authService;
     private final UserService userService;
+    private final LinkCreateService linkCreateService;
 
     /**
      * 할 일 추가
@@ -42,12 +44,22 @@ public class TaskService {
         Collection collection = collectionRepository.findByIdWithUser(request.collectionId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_FOUND_COLLECTION));
 
-        // 3) 권한 확인 (내 모음인지) (403)
+        // 3) 권한 확인
         if (!Arrays.equals(collection.getUser().getUserId(), user.getUserId())) {
             throw new GeneralException(ErrorStatus._UNAUTHORIZED_TASK);
         }
-        
-        // 4) Task 저장
+
+        // 4) 링크가 있으면 OG + 썸네일 처리
+        String thumbnailKey = null;
+
+        if (request.link() != null && !request.link().isBlank()) {
+            LinkCreateResult linkResult =
+                    linkCreateService.create(request.link());
+
+            thumbnailKey = linkResult.thumbnailKey();
+        }
+
+        // 5) Task 저장 (thumbnailKey 포함)
         Task saved = taskRepository.save(
                 Task.builder()
                         .user(user)
@@ -55,12 +67,12 @@ public class TaskService {
                         .title(request.title())
                         .link(request.link())
                         .memo(request.memo())
-                        .inout(true) // 내부추가는 true
-                        .status(false) // 할 일 false 시작
+                        .thumbnailKey(thumbnailKey) 
+                        .inout(true)
+                        .status(false)
                         .build()
         );
 
-        // 4) 응답
         return toResponse(saved);
     }
 
@@ -69,20 +81,16 @@ public class TaskService {
      */
     public List<TaskResponse> listByCollection(Long collectionId) {
 
-        // 1) 유저 조회
         String currentUserId = authService.getAuthenticatedUserId();
         Users user = userService.findExistingUser(currentUserId);
 
-        // 2) 모음 조회 (없으면 404)
         Collection collection = collectionRepository.findByIdWithUser(collectionId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_FOUND_COLLECTION));
 
-        // 3) 권한 확인 (내 모음인지) (403)
         if (!Arrays.equals(collection.getUser().getUserId(), user.getUserId())) {
             throw new GeneralException(ErrorStatus._UNAUTHORIZED_TASK);
         }
 
-        // 4) 해당 모음의 Task 전체 조회
         return taskRepository.findAllByCollection_CollectionIdOrderByTaskIdDesc(collectionId)
                 .stream()
                 .map(this::toResponse)

--- a/src/main/java/com/doLink_server/infra/og/downloader/ImageDownloader.java
+++ b/src/main/java/com/doLink_server/infra/og/downloader/ImageDownloader.java
@@ -1,0 +1,46 @@
+package com.doLink_server.infra.og.downloader;
+
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * - OG 썸네일(외부 URL)을 바이트로 다운로드
+ * - 실패/예외 시 null 반환하여 링크 저장 흐름을 막지 않음
+ */
+@Component
+public class ImageDownloader {
+
+    /** 외부 이미지 요청에 사용되는 HTTP 클라이언트 */
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    /**
+     * - 외부 이미지 URL을 GET으로 조회하여 bytes + contentType 반환
+     * - 응답이 비정상(2xx 아님/본문 없음)이면 null 반환
+     */
+    public DownloadedImage download(String imageUrl) {
+        try {
+            ResponseEntity<byte[]> res = restTemplate.exchange(
+                    imageUrl,
+                    HttpMethod.GET,
+                    new HttpEntity<>(new HttpHeaders()),
+                    byte[].class
+            );
+
+            if (!res.getStatusCode().is2xxSuccessful() || res.getBody() == null) {
+                return null;
+            }
+
+            MediaType ct = res.getHeaders().getContentType();
+            String contentType = (ct != null) ? ct.toString() : "application/octet-stream";
+
+            return new DownloadedImage(res.getBody(), contentType);
+
+        } catch (Exception e) {
+            // 다운로드 실패 시에도 링크 저장 로직을 유지하기 위해 null 반환
+            return null;
+        }
+    }
+    /** - 이미지 바이트와 MIME 타입을 함께 전달하기 위한 record */
+    public record DownloadedImage(byte[] bytes, String contentType) {}
+}

--- a/src/main/java/com/doLink_server/infra/og/dto/LinkPreviewRequest.java
+++ b/src/main/java/com/doLink_server/infra/og/dto/LinkPreviewRequest.java
@@ -1,0 +1,8 @@
+package com.doLink_server.infra.og.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LinkPreviewRequest(
+        @NotBlank String url
+) {
+}

--- a/src/main/java/com/doLink_server/infra/og/dto/OgImageUploadResult.java
+++ b/src/main/java/com/doLink_server/infra/og/dto/OgImageUploadResult.java
@@ -1,0 +1,16 @@
+package com.doLink_server.infra.og.dto;
+
+/**
+ * OG 이미지 처리 결과 DTO
+ *
+ * - 원본(original)과 썸네일(thumbnail) 이미지의
+ *   S3 key 및 Presigned URL을 함께 전달한다.
+ * - 리스트 화면에서는 thumbUrl 위주로 사용한다.
+ */
+public record OgImageUploadResult(
+        String originalKey,
+        String thumbKey,
+        String originalUrl,
+        String thumbUrl
+) {
+}

--- a/src/main/java/com/doLink_server/infra/og/dto/OgMetadata.java
+++ b/src/main/java/com/doLink_server/infra/og/dto/OgMetadata.java
@@ -1,0 +1,14 @@
+package com.doLink_server.infra.og.dto;
+
+/**
+ * - 외부 URL 페이지의 Open Graph(OG) 메타데이터 파싱 결과 DTO
+ * - 링크 저장 시 미리보기 정보(제목, 설명, 썸네일 등) 전달 목적
+ */
+public record OgMetadata(
+        String title,
+        String description,
+        String imageUrl,      // 원본 og:image (외부 URL)
+        String siteName,
+        String canonicalUrl   // og:url 또는 canonical
+) {
+}

--- a/src/main/java/com/doLink_server/infra/og/parser/OgMetadataParser.java
+++ b/src/main/java/com/doLink_server/infra/og/parser/OgMetadataParser.java
@@ -1,0 +1,112 @@
+package com.doLink_server.infra.og.parser;
+
+import com.doLink_server.infra.og.dto.OgMetadata;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+/**
+ * - 외부 URL HTML을 조회하여 OG/Twitter/Title 메타데이터를 파싱
+ * - 파싱 실패 시에도 링크 저장 흐름을 중단하지 않도록 null 기반 결과 반환
+ */
+@Component
+public class OgMetadataParser {
+
+    /** OG 파싱 시 네트워크 지연 방지를 위한 최대 대기 시간 */
+    private static final int TIMEOUT_MS = (int) Duration.ofSeconds(5).toMillis();
+
+    /**
+     * - URL 페이지의 OG 메타데이터를 파싱하여 OgMetadata로 반환
+     * - 일부 메타데이터가 없을 경우 fallback 규칙을 적용
+     * - 예외 발생 시 빈 OgMetadata(null 기반)를 반환
+     */
+    public OgMetadata parse(String url) {
+        try {
+            Document doc = Jsoup.connect(url)
+                    .userAgent("Mozilla/5.0 (compatible; DoLinkBot/1.0)")
+                    .timeout(TIMEOUT_MS)
+                    .followRedirects(true)
+                    .ignoreHttpErrors(true)
+                    .get();
+
+            // OG 메타데이터 우선 추출
+            String ogTitle = meta(doc, "property", "og:title");
+            String ogDesc  = meta(doc, "property", "og:description");
+            String ogImage = meta(doc, "property", "og:image");
+            String ogSite  = meta(doc, "property", "og:site_name");
+            String ogUrl   = meta(doc, "property", "og:url");
+
+            // Twitter 메타데이터 fallback
+            if (isBlank(ogTitle)) ogTitle = meta(doc, "name", "twitter:title");
+            if (isBlank(ogDesc))  ogDesc  = meta(doc, "name", "twitter:description");
+            if (isBlank(ogImage)) ogImage = meta(doc, "name", "twitter:image");
+
+            // title 태그 fallback
+            if (isBlank(ogTitle)) ogTitle = titleTag(doc);
+
+            // canonical URL fallback
+            String canonical = canonical(doc);
+            String finalUrl = !isBlank(ogUrl) ? ogUrl : canonical;
+
+            return new OgMetadata(
+                    trimToNull(ogTitle),
+                    trimToNull(ogDesc),
+                    trimToNull(ogImage),
+                    trimToNull(ogSite),
+                    trimToNull(finalUrl)
+            );
+
+        } catch (Exception e) {
+            // 파싱 실패 시에도 링크 저장 로직을 유지하기 위해 null 기반 결과 반환
+            return new OgMetadata(null, null, null, null, null);
+        }
+    }
+
+    /**
+     * - meta 태그에서 특정 key(property/name)의 content 값을 추출
+     * - 해당 meta 태그가 없을 경우 null 반환
+     */
+    private String meta(Document doc, String keyAttr, String keyValue) {
+        Element el = doc.selectFirst("meta[" + keyAttr + "=" + keyValue + "]");
+        return el != null ? el.attr("content") : null;
+    }
+
+    /**
+     * - <title> 태그의 값을 추출
+     * - title 태그가 없거나 비어 있으면 null 반환
+     */
+    private String titleTag(Document doc) {
+        String t = doc.title();
+        return (t != null && !t.isBlank()) ? t : null;
+    }
+
+    /**
+     * - canonical link 태그에서 대표 URL을 추출
+     * - canonical 태그가 없으면 null 반환
+     */
+    private String canonical(Document doc) {
+        Element el = doc.selectFirst("link[rel=canonical]");
+        return el != null ? el.attr("href") : null;
+    }
+
+    /**
+     * - 문자열이 null 또는 공백인지 여부를 판단
+     */
+    private boolean isBlank(String s) {
+        return s == null || s.isBlank();
+    }
+
+    /**
+     * - 문자열의 앞뒤 공백을 제거
+     * - 결과가 빈 문자열이면 null 반환
+     */
+    private String trimToNull(String s) {
+        if (s == null) return null;
+        String t = s.trim();
+        return t.isEmpty() ? null : t;
+    }
+
+}

--- a/src/main/java/com/doLink_server/infra/og/processor/OgImageProcessor.java
+++ b/src/main/java/com/doLink_server/infra/og/processor/OgImageProcessor.java
@@ -1,0 +1,67 @@
+package com.doLink_server.infra.og.processor;
+
+import com.doLink_server.infra.og.downloader.ImageDownloader;
+import com.doLink_server.infra.og.dto.OgImageUploadResult;
+import com.doLink_server.infra.og.resizer.OgThumbnailResizer;
+import com.doLink_server.infra.s3.OgThumbnailKeyGenerator;
+import com.doLink_server.infra.s3.S3PresignedUrlProvider;
+import com.doLink_server.infra.s3.S3Uploader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * OG 이미지 처리 오케스트레이션 컴포넌트.
+ *
+ * 흐름:
+ * 1. OG 이미지 다운로드
+ * 2. 원본 이미지 S3 업로드
+ * 3. 썸네일 생성 및 업로드
+ * 4. Presigned URL 발급
+ */
+@Component
+@RequiredArgsConstructor
+public class OgImageProcessor {
+
+    private final ImageDownloader downloader;
+    private final OgThumbnailResizer resizer;
+    private final OgThumbnailKeyGenerator keyGenerator;
+    private final S3Uploader uploader;
+    private final S3PresignedUrlProvider presigner;
+
+    /**
+     * @param imageUrl OG 이미지 URL
+     * @return 원본/썸네일 S3 key 및 Presigned URL
+     */
+    public OgImageUploadResult process(String imageUrl) {
+        var downloaded = downloader.download(imageUrl);
+        if (downloaded == null) return null;
+
+        // 1) 원본 업로드
+        String originalKey = keyGenerator.generateOriginal(downloaded.contentType());
+        uploader.uploadPrivate(originalKey, downloaded.bytes(), downloaded.contentType());
+
+        // 2) 썸네일 생성
+        var thumb = resizer.toSquarePng(downloaded.bytes());
+        if (thumb == null) {
+            // 썸네일 실패 시 원본만 반환
+            return new OgImageUploadResult(
+                    originalKey,
+                    null,
+                    presigner.presignGetUrl(originalKey),
+                    null
+            );
+        }
+
+        // 3) 썸네일 업로드
+        String thumbKey = keyGenerator.generateThumbPng();
+        uploader.uploadPrivate(thumbKey, thumb.bytes(), thumb.contentType());
+
+        // 4) Presigned URL 발급
+        return new OgImageUploadResult(
+                originalKey,
+                thumbKey,
+                presigner.presignGetUrl(originalKey),
+                presigner.presignGetUrl(thumbKey)
+        );
+    }
+}

--- a/src/main/java/com/doLink_server/infra/og/resizer/OgThumbnailResizer.java
+++ b/src/main/java/com/doLink_server/infra/og/resizer/OgThumbnailResizer.java
@@ -4,6 +4,8 @@ import net.coobird.thumbnailator.Thumbnails;
 import net.coobird.thumbnailator.geometry.Positions;
 import org.springframework.stereotype.Component;
 
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
@@ -12,12 +14,15 @@ import java.io.ByteArrayOutputStream;
  *
  * - 원본 이미지를 정사각형 cover crop 후
  *   256x256 PNG 썸네일로 변환한다.
- * - 안정성과 호환성을 최우선으로 한다.
+ * - 실패 시 null 반환 (OG 흐름 차단 방지)
  */
 @Component
 public class OgThumbnailResizer {
 
     private static final int SIZE = 256;
+
+    /** 이미지 폭탄 방지를 위한 입력 제한 */
+    private static final int MAX_ORIGINAL_BYTES = 2 * 1024 * 1024;
 
     /**
      * @param originalBytes 원본 이미지 bytes
@@ -28,10 +33,17 @@ public class OgThumbnailResizer {
                 ByteArrayInputStream in = new ByteArrayInputStream(originalBytes);
                 ByteArrayOutputStream out = new ByteArrayOutputStream()
         ) {
-            Thumbnails.of(in)
+            // 이미지 여부 확인 (HTML/PDF 등 차단)
+            BufferedImage image = ImageIO.read(in);
+            if (image == null || originalBytes.length > MAX_ORIGINAL_BYTES) {
+                return null;
+            }
+
+            Thumbnails.of(image)
                     .size(SIZE, SIZE)
-                    .crop(Positions.CENTER)
-                    .outputFormat("png")
+                    .crop(Positions.CENTER)        // 중앙 기준 cover crop
+                    .useExifOrientation(true)      // 모바일 이미지 회전 보정
+                    .outputFormat("png")           // OG 호환성 최우선
                     .outputQuality(0.9)
                     .toOutputStream(out);
 

--- a/src/main/java/com/doLink_server/infra/og/resizer/OgThumbnailResizer.java
+++ b/src/main/java/com/doLink_server/infra/og/resizer/OgThumbnailResizer.java
@@ -1,0 +1,45 @@
+package com.doLink_server.infra.og.resizer;
+
+import net.coobird.thumbnailator.Thumbnails;
+import net.coobird.thumbnailator.geometry.Positions;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+/**
+ * OG 이미지 썸네일 생성 컴포넌트.
+ *
+ * - 원본 이미지를 정사각형 cover crop 후
+ *   256x256 PNG 썸네일로 변환한다.
+ * - 안정성과 호환성을 최우선으로 한다.
+ */
+@Component
+public class OgThumbnailResizer {
+
+    private static final int SIZE = 256;
+
+    /**
+     * @param originalBytes 원본 이미지 bytes
+     * @return PNG 썸네일 이미지 (실패 시 null)
+     */
+    public ResizedImage toSquarePng(byte[] originalBytes) {
+        try (
+                ByteArrayInputStream in = new ByteArrayInputStream(originalBytes);
+                ByteArrayOutputStream out = new ByteArrayOutputStream()
+        ) {
+            Thumbnails.of(in)
+                    .size(SIZE, SIZE)
+                    .crop(Positions.CENTER)
+                    .outputFormat("png")
+                    .outputQuality(0.9)
+                    .toOutputStream(out);
+
+            return new ResizedImage(out.toByteArray(), "image/png");
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public record ResizedImage(byte[] bytes, String contentType) {}
+}

--- a/src/main/java/com/doLink_server/infra/s3/OgThumbnailKeyGenerator.java
+++ b/src/main/java/com/doLink_server/infra/s3/OgThumbnailKeyGenerator.java
@@ -1,0 +1,59 @@
+package com.doLink_server.infra.s3;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * - OG 썸네일 저장용 S3 key 생성
+ * - 날짜 prefix + UUID 기반으로 충돌 없이 생성
+ */
+@Component
+public class OgThumbnailKeyGenerator {
+
+    /**
+     * OG 이미지 원본(original)을 저장하기 위한 S3 Key 생성
+     * 예시: og-image/original/2025/12/17/uuid.jpg
+    */
+    public String generateOriginal(String contentType) {
+        String ext = toExt(contentType);
+        return gen("og-image/original", ext);
+    }
+
+    /**
+     * OG 이미지 썸네일(thumbnail)을 저장하기 위한 S3 Key 생성
+     *
+     * - 리스트/모아보기 화면에서 빠른 로딩과 트래픽 절감을 목적.
+     *  * 예시: og-image/thumb/2025/12/17/uuid.png
+     */
+    public String generateThumbPng() {
+        return gen("og-image/thumb", "png");
+    }
+
+    /**
+     * 공통 S3 Key 생성 로직
+     * 구조: {prefix}/{yyyy}/{MM}/{dd}/{uuid}.{ext}
+     *
+     * @param prefix S3 객체 상위 경로
+     * @param ext    파일 확장자
+     * @return 완성된 S3 key
+     */
+    private String gen(String prefix, String ext) {
+        LocalDate d = LocalDate.now();
+        return String.format("%s/%04d/%02d/%02d/%s.%s",
+                prefix, d.getYear(), d.getMonthValue(), d.getDayOfMonth(),
+                UUID.randomUUID(), ext);
+    }
+
+    private String toExt(String contentType) {
+        if (contentType == null) return "bin";
+        String ct = contentType.toLowerCase();
+        if (ct.contains("jpeg")) return "jpg";
+        if (ct.contains("png"))  return "png";
+        if (ct.contains("webp")) return "webp";
+        if (ct.contains("gif"))  return "gif";
+        return "bin";
+    }
+
+}

--- a/src/main/java/com/doLink_server/infra/s3/S3Config.java
+++ b/src/main/java/com/doLink_server/infra/s3/S3Config.java
@@ -1,0 +1,39 @@
+package com.doLink_server.infra.s3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+/**
+ * S3Config
+ *
+ * - private,Presigned URL 발급용 S3Presigner Bean 등록
+ * - S3 업로드용 S3Client
+ *
+ * 자격 증명은 기본 Credential Provider Chain을 사용:
+ * (로컬: ~/.aws, 배포: IAM Role/Task Role 등)
+ */
+@Configuration
+public class S3Config {
+
+    @Value("${app.aws.region}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .build();
+    }
+
+}

--- a/src/main/java/com/doLink_server/infra/s3/S3PresignedUrlProvider.java
+++ b/src/main/java/com/doLink_server/infra/s3/S3PresignedUrlProvider.java
@@ -1,0 +1,48 @@
+package com.doLink_server.infra.s3;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+
+import java.time.Duration;
+
+/**
+ * S3PresignedUrlProvider
+ *
+ * private S3 객체에 접근할 수 있는 "임시 GET URL"을 발급한다.
+ * - 프론트는 이 URL로 이미지 로딩 (<img src="...">)
+ * - 만료되면 API 재조회 시 새 URL을 받는다.
+ */
+@Component
+@RequiredArgsConstructor
+public class S3PresignedUrlProvider {
+
+    private final S3Presigner presigner;
+
+    @Value("${app.s3.bucket}")
+    private String bucket;
+
+    @Value("${app.s3.presign-expire-minutes:60}") // 만료시간 60분
+    private long expireMinutes;
+
+    /**
+     * @param key S3 객체 key
+     * @return presigned GET URL (문자열)
+     */
+    public String presignGetUrl(String key) {
+        GetObjectRequest getReq = GetObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        GetObjectPresignRequest presignReq = GetObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(expireMinutes))
+                .getObjectRequest(getReq)
+                .build();
+
+        return presigner.presignGetObject(presignReq).url().toString();
+    }
+}

--- a/src/main/java/com/doLink_server/infra/s3/S3Uploader.java
+++ b/src/main/java/com/doLink_server/infra/s3/S3Uploader.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 
 /**
  * S3Uploader
@@ -33,6 +34,7 @@ public class S3Uploader {
                 .bucket(bucket)
                 .key(key)
                 .contentType(contentType)
+                .serverSideEncryption(ServerSideEncryption.AES256) // SSE-S3
                 .build();
 
         s3.putObject(putReq, RequestBody.fromBytes(bytes));

--- a/src/main/java/com/doLink_server/infra/s3/S3Uploader.java
+++ b/src/main/java/com/doLink_server/infra/s3/S3Uploader.java
@@ -1,0 +1,42 @@
+package com.doLink_server.infra.s3;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+/**
+ * S3Uploader
+ *
+ * 썸네일 이미지를 private S3 버킷에 업로드한다.
+ * - Presigned 방식에서는 DB에 URL이 아니라 "S3 key"를 저장한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class S3Uploader {
+
+    private final S3Client s3;
+
+    @Value("${app.s3.bucket}")
+    private String bucket;
+
+    /**
+     * @param key         S3 객체 key (예: og-thumbnail/xxxx.jpg)
+     * @param bytes       이미지 바이트
+     * @param contentType 이미지 MIME 타입 (예: image/jpeg)
+     * @return 저장된 S3 key (URL 아님)
+     */
+    public String uploadPrivate(String key, byte[] bytes, String contentType) {
+        PutObjectRequest putReq = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .contentType(contentType)
+                .build();
+
+        s3.putObject(putReq, RequestBody.fromBytes(bytes));
+        return key;
+    }
+
+}

--- a/src/main/resources/db/migration/V1__add_collection_indexes.sql
+++ b/src/main/resources/db/migration/V1__add_collection_indexes.sql
@@ -5,3 +5,10 @@ CREATE INDEX idx_collection_user_created_at
 -- 카테고리별 모음 조회용 인덱스
 CREATE INDEX idx_collection_user_category_created_at
     ON collection (user_id, category, created_at);
+
+ALTER TABLE dolink.task
+    ADD COLUMN thumbnail_key VARCHAR(500) NULL;
+
+-- B-2 조회 성능을 위해 인덱스 추천
+CREATE INDEX idx_task_collection_created_thumb
+    ON dolink.task (collection_id, created_at, thumbnail_key);


### PR DESCRIPTION
## 🔢 Issue Number
- #11 

## 🎯 기능 개요
- **목적**: 링크가 포함된 Task 생성 시 OG 썸네일을 생성해 S3에 저장하고, 모음 리스트에서 모음별 최신 썸네일 4개를 presigned URL로 제공합니다.

- **예시**:
S3 저장소
<img width="1222" height="374" alt="image" src="https://github.com/user-attachments/assets/fea6c68e-3f45-4738-8b4b-8a53985ce716" />

DB 확인
<img width="1698" height="604" alt="image" src="https://github.com/user-attachments/assets/39999ad5-99b6-4dd4-a3fd-2d346c0f0c9c" />


###  핵심 변경
- OG 이미지 중앙 기준 cover crop
- 256×256 webp (quality 0.85) 썸네일 생성
- 원본 이미지와 썸네일을 분리 저장(S3)
- DB에는 URL 대신 S3 key만 저장, 조회 시 presigned URL 발급


### 핵심 변경(개발자용)
- Task에 thumbnail_key 컬럼 추가 (DB에는 URL이 아닌 S3 key만 저장)
- LinkCreateService로 OG 파싱 → 이미지 다운로드 → 썸네일 생성 → S3 업로드 → presigned URL 발급
- CollectionService에서 모음 리스트 조회 시 모음별 썸네일 최대 4개를 한 번에 조회해 응답에 포함
- LinkController /preview는 OG 처리 결과 확인용(임시)

### 썸네일 정책
- 256×256 중앙 cover crop
- webp(quality 0.85) 목표로 리스트 로딩 최적화 (**용량 70~95%** 절감)

### DB/성능
- task.thumbnail_key 컬럼 추가
- 조회 최적화 인덱스 추가: (collection_id, created_at, thumbnail_key)
→ 모음별 최신 Task 썸네일 4개 조회 성능 개선

## 💌 To Reviewers

이슈1: 할 일 갯수 전달안하는중
할 일 완료하고 갯수 추가해야함
<img width="1317" height="483" alt="image" src="https://github.com/user-attachments/assets/1559480a-a3ca-4032-85db-eff2af2ed3f2" />
<img width="364" height="213" alt="image" src="https://github.com/user-attachments/assets/f586f29b-20c7-434a-bd91-585b681b0491" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 링크 미리보기(OG) 추가 — 제목·설명 추출 및 이미지 처리(썸네일 생성/저장) 지원
  * 링크 미리보기 API 추가 (POST /api/v1/link/preview)
  * 컬렉션 목록에 최대 4개 썸네일 표시 및 썸네일 URL 제공

* **데이터베이스**
  * 링크 썸네일 저장용 컬럼 및 인덱스 추가 (썸네일 키 및 관련 인덱스)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->