### PR TITLE
FEAT/search-Task-Collection

### DIFF
--- a/src/main/java/com/doLink_server/domain/collection/repository/CollectionRepository.java
+++ b/src/main/java/com/doLink_server/domain/collection/repository/CollectionRepository.java
@@ -63,4 +63,8 @@ public interface CollectionRepository extends JpaRepository<Collection, Long> {
     List<Collection> findAllByUser(Users user);
 
 
+    /**
+     * [검색용] 사용자별 모음 이름 포함 검색 (페이징)
+     */
+    Slice<Collection> findByUserAndNameContaining(Users user, String keyword, Pageable pageable);
 }

--- a/src/main/java/com/doLink_server/domain/search/controller/SearchController.java
+++ b/src/main/java/com/doLink_server/domain/search/controller/SearchController.java
@@ -1,0 +1,65 @@
+package com.doLink_server.domain.search.controller;
+
+import com.doLink_server.domain.collection.dto.CollectionResponse;
+import com.doLink_server.domain.search.dto.SearchResponse;
+import com.doLink_server.domain.search.service.SearchService;
+import com.doLink_server.domain.task.dto.TaskResponse;
+import com.doLink_server.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/search")
+@Tag(name = "Search", description = "통합 검색 API")
+public class SearchController {
+
+    private final SearchService searchService;
+
+    /**
+     * 초기 검색 (모음, 할 일 각각 최대 5개씩)
+     * GET /api/v1/search/preview?keyword=검색어
+     */
+    @GetMapping("/preview")
+    @Operation(summary = "초기 검색 미리보기", description = "키워드가 포함된 모음과 할 일을 각각 최대 5개씩 조회한다.")
+    public ApiResponse<SearchResponse> searchPreview(
+            @Parameter(description = "검색어") @RequestParam String keyword
+    ) {
+        return ApiResponse.onSuccess(searchService.searchPreview(keyword));
+    }
+
+    /**
+     * 모음 검색 (이름에 키워드 포함)
+     * GET /api/v1/search/collections?keyword=검색어&page=0&size=10
+     */
+    @GetMapping("/collections")
+    @Operation(summary = "모음 검색", description = "키워드가 이름에 포함된 모음을 페이징하여 조회한다.")
+    public ApiResponse<Slice<CollectionResponse>> searchCollections(
+            @Parameter(description = "검색어") @RequestParam String keyword,
+            @Parameter(description = "페이지 번호 (0부터 시작)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "10") int size
+    ) {
+        return ApiResponse.onSuccess(searchService.searchCollections(keyword, page, size));
+    }
+
+    /**
+     * 할 일 검색 (제목에 키워드 포함)
+     * GET /api/v1/search/tasks?keyword=검색어&page=0&size=10
+     */
+    @GetMapping("/tasks")
+    @Operation(summary = "할 일 검색", description = "키워드가 제목에 포함된 할 일을 페이징하여 조회한다.")
+    public ApiResponse<Slice<TaskResponse>> searchTasks(
+            @Parameter(description = "검색어") @RequestParam String keyword,
+            @Parameter(description = "페이지 번호 (0부터 시작)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "10") int size
+    ) {
+        return ApiResponse.onSuccess(searchService.searchTasks(keyword, page, size));
+    }
+}

--- a/src/main/java/com/doLink_server/domain/search/dto/SearchResponse.java
+++ b/src/main/java/com/doLink_server/domain/search/dto/SearchResponse.java
@@ -1,0 +1,16 @@
+package com.doLink_server.domain.search.dto;
+
+import com.doLink_server.domain.collection.dto.CollectionResponse;
+import com.doLink_server.domain.task.dto.TaskResponse;
+import lombok.Builder;
+import org.springframework.data.domain.Slice;
+
+/**
+ * 통합 검색 결과 응답 DTO
+ */
+@Builder
+public record SearchResponse(
+        Slice<CollectionResponse> collections, // 검색된 모음 목록
+        Slice<TaskResponse> tasks              // 검색된 할 일 목록
+) {
+}

--- a/src/main/java/com/doLink_server/domain/search/service/SearchService.java
+++ b/src/main/java/com/doLink_server/domain/search/service/SearchService.java
@@ -1,0 +1,147 @@
+package com.doLink_server.domain.search.service;
+
+import com.doLink_server.auth.service.AuthService;
+import com.doLink_server.domain.collection.dto.CollectionResponse;
+import com.doLink_server.domain.collection.entity.Collection;
+import com.doLink_server.domain.collection.repository.CollectionRepository;
+import com.doLink_server.domain.search.dto.SearchResponse;
+import com.doLink_server.domain.task.dto.TaskResponse;
+import com.doLink_server.domain.task.entity.Task;
+import com.doLink_server.domain.task.repository.TaskRepository;
+import com.doLink_server.user.entity.Users;
+import com.doLink_server.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SearchService {
+
+    private final AuthService authService;
+    private final UserService userService;
+    private final CollectionRepository collectionRepository;
+    private final TaskRepository taskRepository;
+
+    /**
+     * 초기 검색 미리보기 (모음, 할 일 각각 최대 5개)
+     * - 최신순(created_at DESC) 정렬
+     */
+    public SearchResponse searchPreview(String keyword) {
+        // 1. 로그인 유저 조회
+        String currentUserId = authService.getAuthenticatedUserId();
+        Users user = userService.findExistingUser(currentUserId);
+
+        // 2. 페이징 설정 (최신순, 최대 5개)
+        PageRequest pageable = PageRequest.of(0, 5, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        // 3. 키워드가 없거나 공백이면 빈 Slice 반환
+        if (keyword == null || keyword.trim().isEmpty()) {
+            Slice<CollectionResponse> emptyCollections = new SliceImpl<>(Collections.emptyList(), pageable, false);
+            Slice<TaskResponse> emptyTasks = new SliceImpl<>(Collections.emptyList(), pageable, false);
+
+            return SearchResponse.builder()
+                    .collections(emptyCollections)
+                    .tasks(emptyTasks)
+                    .build();
+        }
+
+        // 4. 모음 이름 검색 (최대 5개)
+        Slice<Collection> collectionSlice = collectionRepository.findByUserAndNameContaining(user, keyword, pageable);
+        Slice<CollectionResponse> collectionResponses = collectionSlice.map(c -> CollectionResponse.builder()
+                .collectionId(c.getCollectionId())
+                .name(c.getName())
+                .category(c.getCategory())
+                .thumbnails(List.of())
+                .build());
+
+        // 5. 할 일 제목 검색 (최대 5개)
+        Slice<Task> taskSlice = taskRepository.findByUserAndTitleContaining(user, keyword, pageable);
+        Slice<TaskResponse> taskResponses = taskSlice.map(t -> TaskResponse.builder()
+                .taskId(t.getTaskId())
+                .collectionId(t.getCollection().getCollectionId())
+                .title(t.getTitle())
+                .link(t.getLink())
+                .memo(t.getMemo())
+                .status(t.getStatus())
+                .inout(t.getInout())
+                .createdAt(t.getCreatedAt())
+                .build());
+
+        // 6. 결과 반환
+        return SearchResponse.builder()
+                .collections(collectionResponses)
+                .tasks(taskResponses)
+                .build();
+    }
+
+    /**
+     * 모음 검색 (이름에 키워드 포함, 페이징)
+     * - 최신순(created_at DESC) 정렬
+     */
+    public Slice<CollectionResponse> searchCollections(String keyword, int page, int size) {
+        // 1. 로그인 유저 조회
+        String currentUserId = authService.getAuthenticatedUserId();
+        Users user = userService.findExistingUser(currentUserId);
+
+        // 2. 페이징 설정 (최신순)
+        PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        // 3. 키워드가 없거나 공백이면 빈 Slice 반환
+        if (keyword == null || keyword.trim().isEmpty()) {
+            return new SliceImpl<>(Collections.emptyList(), pageable, false);
+        }
+
+        // 4. 모음 이름 검색
+        Slice<Collection> collectionSlice = collectionRepository.findByUserAndNameContaining(user, keyword, pageable);
+
+        // 5. DTO 변환 후 반환
+        return collectionSlice.map(c -> CollectionResponse.builder()
+                .collectionId(c.getCollectionId())
+                .name(c.getName())
+                .category(c.getCategory())
+                .thumbnails(List.of()) // 검색 목록에서는 썸네일 생략 (성능 최적화)
+                .build());
+    }
+
+    /**
+     * 할 일 검색 (제목에 키워드 포함, 페이징)
+     * - 최신순(created_at DESC) 정렬
+     */
+    public Slice<TaskResponse> searchTasks(String keyword, int page, int size) {
+        // 1. 로그인 유저 조회
+        String currentUserId = authService.getAuthenticatedUserId();
+        Users user = userService.findExistingUser(currentUserId);
+
+        // 2. 페이징 설정 (최신순)
+        PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        // 3. 키워드가 없거나 공백이면 빈 Slice 반환
+        if (keyword == null || keyword.trim().isEmpty()) {
+            return new SliceImpl<>(Collections.emptyList(), pageable, false);
+        }
+
+        // 4. 할 일 제목 검색
+        Slice<Task> taskSlice = taskRepository.findByUserAndTitleContaining(user, keyword, pageable);
+
+        // 5. DTO 변환 후 반환
+        return taskSlice.map(t -> TaskResponse.builder()
+                .taskId(t.getTaskId())
+                .collectionId(t.getCollection().getCollectionId())
+                .title(t.getTitle())
+                .link(t.getLink())
+                .memo(t.getMemo())
+                .status(t.getStatus())
+                .inout(t.getInout())
+                .createdAt(t.getCreatedAt())
+                .build());
+    }
+}

--- a/src/main/java/com/doLink_server/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/doLink_server/domain/task/repository/TaskRepository.java
@@ -2,6 +2,7 @@ package com.doLink_server.domain.task.repository;
 
 import com.doLink_server.domain.task.entity.Task;
 
+import com.doLink_server.user.entity.Users;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -61,4 +62,9 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
      * 모음별 Task 전체 조회 (페이징, 무한 스크롤)
      */
     Slice<Task> findAllByCollection_CollectionId(Long collectionId, Pageable pageable);
+
+    /**
+     * [검색용] 사용자별 할 일 제목 포함 검색 (페이징)
+     */
+    Slice<Task> findByUserAndTitleContaining(Users user, String keyword, Pageable pageable);
 }


### PR DESCRIPTION
## 🔢 Issue Number
#15 

## 🎯 기능 개요
- 목적: 검색 UX 개선을 위해 `Task`/ `Collection` 검색을 분리하고, 초기 검색 시 미리보기(프리뷰) 결과를 제공

## 🏗 구현 상세 및 설계 문서
- 초기 검색 미리보기 - `GET /api/v1/search/preview?keyword=...`
- 모음 검색(페이징) - `GET /api/v1/search/collections?keyword=...&page=0&size=10`
- 할 일 검색(페이징) - `GET /api/v1/search/tasks?keyword=...&page=0&size=10`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 검색 기능 추가: 키워드를 통해 컬렉션과 작업을 검색할 수 있습니다.
* 미리보기 검색: 검색 키워드에 대한 최신 결과를 빠르게 확인합니다.
* 페이지네이션 지원: 검색된 컬렉션과 작업을 페이지 단위로 조회할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->