### PR TITLE
feat: 할 일 완료 처리 기능 구현

### DIFF
--- a/src/main/java/com/doLink_server/domain/search/controller/SearchController.java
+++ b/src/main/java/com/doLink_server/domain/search/controller/SearchController.java
@@ -27,13 +27,13 @@ public class SearchController {
      * 초기 검색 (모음, 할 일 각각 최대 5개씩)
      * GET /api/v1/search/preview?keyword=검색어
      */
-    @GetMapping("/preview")
-    @Operation(summary = "초기 검색 미리보기", description = "키워드가 포함된 모음과 할 일을 각각 최대 5개씩 조회한다.")
-    public ApiResponse<SearchResponse> searchPreview(
-            @Parameter(description = "검색어") @RequestParam String keyword
-    ) {
-        return ApiResponse.onSuccess(searchService.searchPreview(keyword));
-    }
+//    @GetMapping("/preview")
+//    @Operation(summary = "초기 검색 미리보기", description = "키워드가 포함된 모음과 할 일을 각각 최대 5개씩 조회한다.")
+//    public ApiResponse<SearchResponse> searchPreview(
+//            @Parameter(description = "검색어") @RequestParam String keyword
+//    ) {
+//        return ApiResponse.onSuccess(searchService.searchPreview(keyword));
+//    }
 
     /**
      * 모음 검색 (이름에 키워드 포함)

--- a/src/main/java/com/doLink_server/domain/search/dto/SearchResponse.java
+++ b/src/main/java/com/doLink_server/domain/search/dto/SearchResponse.java
@@ -3,14 +3,18 @@ package com.doLink_server.domain.search.dto;
 import com.doLink_server.domain.collection.dto.CollectionResponse;
 import com.doLink_server.domain.task.dto.TaskResponse;
 import lombok.Builder;
-import org.springframework.data.domain.Slice;
+
+import java.util.List;
 
 /**
  * 통합 검색 결과 응답 DTO
+ * - 각각 최대 5개까지 반환
  */
 @Builder
 public record SearchResponse(
-        Slice<CollectionResponse> collections, // 검색된 모음 목록
-        Slice<TaskResponse> tasks              // 검색된 할 일 목록
+        List<CollectionResponse> collections, // 검색된 모음 목록 (최대 5개)
+        List<TaskResponse> tasks,             // 검색된 할 일 목록 (최대 5개)
+        Boolean hasMoreCollections,           // 모음이 5개보다 더 많은지 여부
+        Boolean hasMoreTasks                  // 할 일이 5개보다 더 많은지 여부
 ) {
 }

--- a/src/main/java/com/doLink_server/domain/search/service/SearchService.java
+++ b/src/main/java/com/doLink_server/domain/search/service/SearchService.java
@@ -43,43 +43,48 @@ public class SearchService {
         // 2. 페이징 설정 (최신순, 최대 5개)
         PageRequest pageable = PageRequest.of(0, 5, Sort.by(Sort.Direction.DESC, "createdAt"));
 
-        // 3. 키워드가 없거나 공백이면 빈 Slice 반환
+        // 3. 키워드가 없거나 공백이면 빈 List 반환
         if (keyword == null || keyword.trim().isEmpty()) {
-            Slice<CollectionResponse> emptyCollections = new SliceImpl<>(Collections.emptyList(), pageable, false);
-            Slice<TaskResponse> emptyTasks = new SliceImpl<>(Collections.emptyList(), pageable, false);
-
             return SearchResponse.builder()
-                    .collections(emptyCollections)
-                    .tasks(emptyTasks)
+                    .collections(Collections.emptyList())
+                    .tasks(Collections.emptyList())
+                    .hasMoreCollections(false)
+                    .hasMoreTasks(false)
                     .build();
         }
 
         // 4. 모음 이름 검색 (최대 5개)
         Slice<Collection> collectionSlice = collectionRepository.findByUserAndNameContaining(user, keyword, pageable);
-        Slice<CollectionResponse> collectionResponses = collectionSlice.map(c -> CollectionResponse.builder()
-                .collectionId(c.getCollectionId())
-                .name(c.getName())
-                .category(c.getCategory())
-                .thumbnails(List.of())
-                .build());
+        List<CollectionResponse> collectionResponses = collectionSlice.getContent().stream()
+                .map(c -> CollectionResponse.builder()
+                        .collectionId(c.getCollectionId())
+                        .name(c.getName())
+                        .category(c.getCategory())
+                        .thumbnails(List.of())
+                        .build())
+                .toList();
 
         // 5. 할 일 제목 검색 (최대 5개)
         Slice<Task> taskSlice = taskRepository.findByUserAndTitleContaining(user, keyword, pageable);
-        Slice<TaskResponse> taskResponses = taskSlice.map(t -> TaskResponse.builder()
-                .taskId(t.getTaskId())
-                .collectionId(t.getCollection().getCollectionId())
-                .title(t.getTitle())
-                .link(t.getLink())
-                .memo(t.getMemo())
-                .status(t.getStatus())
-                .inout(t.getInout())
-                .createdAt(t.getCreatedAt())
-                .build());
+        List<TaskResponse> taskResponses = taskSlice.getContent().stream()
+                .map(t -> TaskResponse.builder()
+                        .taskId(t.getTaskId())
+                        .collectionId(t.getCollection().getCollectionId())
+                        .title(t.getTitle())
+                        .link(t.getLink())
+                        .memo(t.getMemo())
+                        .status(t.getStatus())
+                        .inout(t.getInout())
+                        .createdAt(t.getCreatedAt())
+                        .build())
+                .toList();
 
-        // 6. 결과 반환
+        // 6. 결과 반환 (hasNext()로 더 많은 결과가 있는지 확인)
         return SearchResponse.builder()
                 .collections(collectionResponses)
                 .tasks(taskResponses)
+                .hasMoreCollections(collectionSlice.hasNext())
+                .hasMoreTasks(taskSlice.hasNext())
                 .build();
     }
 

--- a/src/main/java/com/doLink_server/domain/search/service/SearchService.java
+++ b/src/main/java/com/doLink_server/domain/search/service/SearchService.java
@@ -64,9 +64,11 @@ public class SearchService {
                     .map(Collection::getCollectionId)
                     .toList();
 
+            // 6. 여러 모음에 대해 모음별 대표 썸네일 최대 4개를 한 번에 조회
             List<CollectionThumbnailRow> thumbnailRows =
                     taskRepository.findTop4ThumbnailsByCollectionIds(collectionIds);
 
+            // 7. 컬렉션 ID별 썸네일 키 매핑
             Map<Long, List<String>> thumbKeyMap = thumbnailRows.stream()
                     .collect(Collectors.groupingBy(
                             CollectionThumbnailRow::getCollectionId,
@@ -76,6 +78,7 @@ public class SearchService {
                             )
                     ));
 
+            // 8. DTO 변환
             collectionResponses = collections.stream()
                     .map(c -> {
                         List<String> thumbnailUrls = thumbKeyMap

--- a/src/main/java/com/doLink_server/domain/search/service/SearchService.java
+++ b/src/main/java/com/doLink_server/domain/search/service/SearchService.java
@@ -7,7 +7,9 @@ import com.doLink_server.domain.collection.repository.CollectionRepository;
 import com.doLink_server.domain.search.dto.SearchResponse;
 import com.doLink_server.domain.task.dto.TaskResponse;
 import com.doLink_server.domain.task.entity.Task;
+import com.doLink_server.domain.task.repository.CollectionThumbnailRow;
 import com.doLink_server.domain.task.repository.TaskRepository;
+import com.doLink_server.infra.s3.S3PresignedUrlProvider;
 import com.doLink_server.user.entity.Users;
 import com.doLink_server.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -30,63 +34,7 @@ public class SearchService {
     private final UserService userService;
     private final CollectionRepository collectionRepository;
     private final TaskRepository taskRepository;
-
-    /**
-     * 초기 검색 미리보기 (모음, 할 일 각각 최대 5개)
-     * - 최신순(created_at DESC) 정렬
-     */
-    public SearchResponse searchPreview(String keyword) {
-        // 1. 로그인 유저 조회
-        String currentUserId = authService.getAuthenticatedUserId();
-        Users user = userService.findExistingUser(currentUserId);
-
-        // 2. 페이징 설정 (최신순, 최대 5개)
-        PageRequest pageable = PageRequest.of(0, 5, Sort.by(Sort.Direction.DESC, "createdAt"));
-
-        // 3. 키워드가 없거나 공백이면 빈 List 반환
-        if (keyword == null || keyword.trim().isEmpty()) {
-            return SearchResponse.builder()
-                    .collections(Collections.emptyList())
-                    .tasks(Collections.emptyList())
-                    .hasMoreCollections(false)
-                    .hasMoreTasks(false)
-                    .build();
-        }
-
-        // 4. 모음 이름 검색 (최대 5개)
-        Slice<Collection> collectionSlice = collectionRepository.findByUserAndNameContaining(user, keyword, pageable);
-        List<CollectionResponse> collectionResponses = collectionSlice.getContent().stream()
-                .map(c -> CollectionResponse.builder()
-                        .collectionId(c.getCollectionId())
-                        .name(c.getName())
-                        .category(c.getCategory())
-                        .thumbnails(List.of())
-                        .build())
-                .toList();
-
-        // 5. 할 일 제목 검색 (최대 5개)
-        Slice<Task> taskSlice = taskRepository.findByUserAndTitleContaining(user, keyword, pageable);
-        List<TaskResponse> taskResponses = taskSlice.getContent().stream()
-                .map(t -> TaskResponse.builder()
-                        .taskId(t.getTaskId())
-                        .collectionId(t.getCollection().getCollectionId())
-                        .title(t.getTitle())
-                        .link(t.getLink())
-                        .memo(t.getMemo())
-                        .status(t.getStatus())
-                        .inout(t.getInout())
-                        .createdAt(t.getCreatedAt())
-                        .build())
-                .toList();
-
-        // 6. 결과 반환 (hasNext()로 더 많은 결과가 있는지 확인)
-        return SearchResponse.builder()
-                .collections(collectionResponses)
-                .tasks(taskResponses)
-                .hasMoreCollections(collectionSlice.hasNext())
-                .hasMoreTasks(taskSlice.hasNext())
-                .build();
-    }
+    private final S3PresignedUrlProvider s3PresignedUrlProvider;
 
     /**
      * 모음 검색 (이름에 키워드 포함, 페이징)
@@ -107,14 +55,48 @@ public class SearchService {
 
         // 4. 모음 이름 검색
         Slice<Collection> collectionSlice = collectionRepository.findByUserAndNameContaining(user, keyword, pageable);
+        List<Collection> collections = collectionSlice.getContent();
 
-        // 5. DTO 변환 후 반환
-        return collectionSlice.map(c -> CollectionResponse.builder()
-                .collectionId(c.getCollectionId())
-                .name(c.getName())
-                .category(c.getCategory())
-                .thumbnails(List.of()) // 검색 목록에서는 썸네일 생략 (성능 최적화)
-                .build());
+        // 5. 썸네일 포함하여 DTO 변환
+        List<CollectionResponse> collectionResponses;
+        if (!collections.isEmpty()) {
+            List<Long> collectionIds = collections.stream()
+                    .map(Collection::getCollectionId)
+                    .toList();
+
+            List<CollectionThumbnailRow> thumbnailRows =
+                    taskRepository.findTop4ThumbnailsByCollectionIds(collectionIds);
+
+            Map<Long, List<String>> thumbKeyMap = thumbnailRows.stream()
+                    .collect(Collectors.groupingBy(
+                            CollectionThumbnailRow::getCollectionId,
+                            Collectors.mapping(
+                                    CollectionThumbnailRow::getThumbnailKey,
+                                    Collectors.toList()
+                            )
+                    ));
+
+            collectionResponses = collections.stream()
+                    .map(c -> {
+                        List<String> thumbnailUrls = thumbKeyMap
+                                .getOrDefault(c.getCollectionId(), List.of())
+                                .stream()
+                                .map(s3PresignedUrlProvider::presignGetUrl)
+                                .toList();
+
+                        return CollectionResponse.builder()
+                                .collectionId(c.getCollectionId())
+                                .name(c.getName())
+                                .category(c.getCategory())
+                                .thumbnails(thumbnailUrls)
+                                .build();
+                    })
+                    .toList();
+        } else {
+            collectionResponses = Collections.emptyList();
+        }
+
+        return new SliceImpl<>(collectionResponses, pageable, collectionSlice.hasNext());
     }
 
     /**
@@ -138,15 +120,45 @@ public class SearchService {
         Slice<Task> taskSlice = taskRepository.findByUserAndTitleContaining(user, keyword, pageable);
 
         // 5. DTO 변환 후 반환
-        return taskSlice.map(t -> TaskResponse.builder()
+        return taskSlice.map(t -> {
+            String thumbnailUrl = null;
+            if (t.getThumbnailKey() != null && !t.getThumbnailKey().isBlank()) {
+                thumbnailUrl = s3PresignedUrlProvider.presignGetUrl(t.getThumbnailKey());
+            }
+
+            return TaskResponse.builder()
+                    .taskId(t.getTaskId())
+                    .collectionId(t.getCollection().getCollectionId())
+                    .title(t.getTitle())
+                    .link(t.getLink())
+                    .memo(t.getMemo())
+                    .thumbnailUrl(thumbnailUrl)
+                    .status(t.getStatus())
+                    .inout(t.getInout())
+                    .createdAt(t.getCreatedAt())
+                    .build();
+        });
+    }
+
+    /**
+     * Task를 TaskResponse로 변환하는 헬퍼 메서드
+     */
+    private TaskResponse toTaskResponse(Task t) {
+        String thumbnailUrl = null;
+        if (t.getThumbnailKey() != null && !t.getThumbnailKey().isBlank()) {
+            thumbnailUrl = s3PresignedUrlProvider.presignGetUrl(t.getThumbnailKey());
+        }
+
+        return TaskResponse.builder()
                 .taskId(t.getTaskId())
                 .collectionId(t.getCollection().getCollectionId())
                 .title(t.getTitle())
                 .link(t.getLink())
                 .memo(t.getMemo())
+                .thumbnailUrl(thumbnailUrl)
                 .status(t.getStatus())
                 .inout(t.getInout())
                 .createdAt(t.getCreatedAt())
-                .build());
+                .build();
     }
 }

--- a/src/main/java/com/doLink_server/domain/task/controller/TaskController.java
+++ b/src/main/java/com/doLink_server/domain/task/controller/TaskController.java
@@ -12,8 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/task")
@@ -30,15 +28,6 @@ public class TaskController {
     public ApiResponse<TaskResponse> create(@Valid @RequestBody TaskCreateRequest request) {
         return ApiResponse.onSuccess(taskService.taskCreate(request));
     }
-
-    /**
-     * 모음별 Task 전체 조회, 페이지네이션으로 마이그레이션 필요!!
-     */
-//    @GetMapping("/collections/{collectionId}")
-//    @Operation(summary = "모음별 Task 전체 조회", description = "collectionId에 속한 Task를 전부 조회한다.")
-//    public ApiResponse<List<TaskResponse>> listByCollection(@PathVariable Long collectionId) {
-//        return ApiResponse.onSuccess(taskService.listByCollection(collectionId));
-//    }
 
     /**
      * 모음별 Task 전체 조회 (페이징, 무한 스크롤)
@@ -73,6 +62,15 @@ public class TaskController {
             @RequestBody TaskUpdateRequest request
     ) {
         return ApiResponse.onSuccess(taskService.updateTask(taskId, request));
+    }
+
+    /**
+     * 할 일 완료 처리
+     */
+    @PatchMapping("/{taskId}/complete")
+    @Operation(summary = "할 일 완료 처리", description = "할 일의 상태를 완료(true)로 변경한다.")
+    public ApiResponse<TaskResponse> completeTask(@PathVariable Long taskId) {
+        return ApiResponse.onSuccess(taskService.completeTask(taskId));
     }
 
     /**

--- a/src/main/java/com/doLink_server/domain/task/controller/TaskController.java
+++ b/src/main/java/com/doLink_server/domain/task/controller/TaskController.java
@@ -38,9 +38,10 @@ public class TaskController {
             @PathVariable Long collectionId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
-            @RequestParam(defaultValue = "desc") String sort
+            @RequestParam(defaultValue = "desc") String sort,
+            @RequestParam(required = false) Boolean completed
     ) {
-        return ApiResponse.onSuccess(taskService.listByCollection(collectionId, page, size, sort));
+        return ApiResponse.onSuccess(taskService.listByCollection(collectionId, page, size, sort, completed));
     }
 
     /**

--- a/src/main/java/com/doLink_server/domain/task/dto/TaskResponse.java
+++ b/src/main/java/com/doLink_server/domain/task/dto/TaskResponse.java
@@ -11,6 +11,7 @@ public record TaskResponse(
         String title,
         String link,
         String memo,
+        String thumbnailUrl,
         Boolean status,
         Boolean inout,
         LocalDateTime createdAt

--- a/src/main/java/com/doLink_server/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/doLink_server/domain/task/repository/TaskRepository.java
@@ -64,6 +64,13 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     Slice<Task> findAllByCollection_CollectionId(Long collectionId, Pageable pageable);
 
     /**
+     * 모음별 Task 전체 조회 (페이징, 무한 스크롤) + 완료/미완료 필터
+     *
+     * @param status true: 완료, false: 미완료
+     */
+    Slice<Task> findAllByCollection_CollectionIdAndStatus(Long collectionId, Boolean status, Pageable pageable);
+
+    /**
      * [검색용] 사용자별 할 일 제목 포함 검색 (페이징)
      */
     Slice<Task> findByUserAndTitleContaining(Users user, String keyword, Pageable pageable);

--- a/src/main/java/com/doLink_server/domain/task/service/TaskService.java
+++ b/src/main/java/com/doLink_server/domain/task/service/TaskService.java
@@ -21,7 +21,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -81,27 +80,6 @@ public class TaskService {
 
         return toResponse(saved);
     }
-
-    /**
-     * 모음별 Task 전체 조회
-     */
-//    public List<TaskResponse> listByCollection(Long collectionId) {
-//
-//        String currentUserId = authService.getAuthenticatedUserId();
-//        Users user = userService.findExistingUser(currentUserId);
-//
-//        Collection collection = collectionRepository.findByIdWithUser(collectionId)
-//                .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_FOUND_COLLECTION));
-//
-//        if (!Arrays.equals(collection.getUser().getUserId(), user.getUserId())) {
-//            throw new GeneralException(ErrorStatus._UNAUTHORIZED_TASK);
-//        }
-//
-//        return taskRepository.findAllByCollection_CollectionIdOrderByTaskIdDesc(collectionId)
-//                .stream()
-//                .map(this::toResponse)
-//                .toList();
-//    }
 
     /**
      * 단일 Task 조회
@@ -175,6 +153,32 @@ public class TaskService {
                 task.updateLink(newLink, linkResult.originalKey(), linkResult.thumbnailKey());
             }
         }
+
+        return toResponse(task);
+    }
+
+    /**
+     * 할 일 완료 처리
+     */
+    @Transactional
+    public TaskResponse completeTask(Long taskId) {
+        String currentUserId = authService.getAuthenticatedUserId();
+        Users user = userService.findExistingUser(currentUserId);
+
+        Task task = taskRepository.findByIdWithUserAndCollection(taskId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_FOUND_TASK));
+
+        // 권한 확인
+        if (!Arrays.equals(task.getUser().getUserId(), user.getUserId())) {
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED_TASK);
+        }
+
+        // 이미 완료인 경우 그냥 현재 상태 반환
+        if (Boolean.TRUE.equals(task.getStatus())) {
+            return toResponse(task);
+        }
+
+        task.setStatus(true);
 
         return toResponse(task);
     }

--- a/src/main/java/com/doLink_server/domain/task/service/TaskService.java
+++ b/src/main/java/com/doLink_server/domain/task/service/TaskService.java
@@ -103,7 +103,7 @@ public class TaskService {
     /**
      * 모음별 Task 전체 조회 (페이징)
      */
-    public Slice<TaskResponse> listByCollection(Long collectionId, int page, int size, String sort) {
+    public Slice<TaskResponse> listByCollection(Long collectionId, int page, int size, String sort, Boolean completed) {
         String currentUserId = authService.getAuthenticatedUserId();
         Users user = userService.findExistingUser(currentUserId);
 
@@ -117,11 +117,25 @@ public class TaskService {
 
         Sort.Direction direction = "asc".equalsIgnoreCase(sort) ? Sort.Direction.ASC : Sort.Direction.DESC;
 
-        // 정렬: Task ID 기준 내림차순 (최신순)
+        // 정렬: Task ID 기준
         PageRequest pageable = PageRequest.of(page, size, Sort.by(direction, "taskId"));
 
-        return taskRepository.findAllByCollection_CollectionId(collectionId, pageable)
+        if (completed == null) {
+            return taskRepository.findAllByCollection_CollectionId(collectionId, pageable)
+                    .map(this::toResponse);
+        }
+
+        // completed=true -> status=true(완료), completed=false -> status=false(미완료)
+        return taskRepository.findAllByCollection_CollectionIdAndStatus(collectionId, completed, pageable)
                 .map(this::toResponse);
+    }
+
+    /**
+     * 모음별 Task 전체 조회 (페이징)
+     * - 하위 호환용 오버로드 (필터 없음)
+     */
+    public Slice<TaskResponse> listByCollection(Long collectionId, int page, int size, String sort) {
+        return listByCollection(collectionId, page, size, sort, null);
     }
 
     /**

--- a/src/main/java/com/doLink_server/domain/task/service/TaskService.java
+++ b/src/main/java/com/doLink_server/domain/task/service/TaskService.java
@@ -11,6 +11,7 @@ import com.doLink_server.domain.task.entity.Task;
 import com.doLink_server.domain.task.repository.TaskRepository;
 import com.doLink_server.global.common.status.ErrorStatus;
 import com.doLink_server.global.exception.GeneralException;
+import com.doLink_server.infra.s3.S3PresignedUrlProvider;
 import com.doLink_server.user.entity.Users;
 import com.doLink_server.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +33,7 @@ public class TaskService {
     private final AuthService authService;
     private final UserService userService;
     private final LinkCreateService linkCreateService;
+    private final S3PresignedUrlProvider s3PresignedUrlProvider;
 
     /**
      * 할 일 추가
@@ -202,12 +204,18 @@ public class TaskService {
     }
 
     private TaskResponse toResponse(Task t) {
+        String thumbnailUrl = null;
+        if (t.getThumbnailKey() != null && !t.getThumbnailKey().isBlank()) {
+            thumbnailUrl = s3PresignedUrlProvider.presignGetUrl(t.getThumbnailKey());
+        }
+
         return TaskResponse.builder()
                 .taskId(t.getTaskId())
                 .collectionId(t.getCollection().getCollectionId())
                 .title(t.getTitle())
                 .link(t.getLink())
                 .memo(t.getMemo())
+                .thumbnailUrl(thumbnailUrl)
                 .status(t.getStatus())
                 .inout(t.getInout())
                 .createdAt(t.getCreatedAt())

--- a/src/main/java/com/doLink_server/security/filter/CustomLogoutFilter.java
+++ b/src/main/java/com/doLink_server/security/filter/CustomLogoutFilter.java
@@ -42,7 +42,7 @@ public class CustomLogoutFilter extends GenericFilterBean {
 
     /**
      * 로그아웃 요청 처리 메서드
-
+     * <p>
      * 요청 URI와 HTTP 메서드를 확인하여 로그아웃 API 요청인지 판단합니다.
      * 로그아웃 요청인 경우, 쿠키에서 refresh 토큰을 추출하고 유효성 검증을 수행합니다.
      * Redis에 저장된 토큰과 일치하는지 확인 후 로그아웃 처리(토큰 삭제, 쿠키 만료 설정)를 진행합니다.
@@ -67,13 +67,13 @@ public class CustomLogoutFilter extends GenericFilterBean {
         }
 
         // 2. 쿠키에서 refresh 토큰 추출
-        try{
+        try {
             Cookie[] cookies = request.getCookies();
             String refreshToken = jwtIssueService.getRefreshTokenFromCookie(cookies);
 
             // Redis에 저장된 refresh 토큰 확인
             String userId = jwtProvider.getUserId(refreshToken);
-            if(redisService.isInvalidRefreshToken(userId, refreshToken)){
+            if (redisService.isInvalidRefreshToken(userId, refreshToken)) {
                 log.error("Redis에 저장된 RefreshToken과 불일치");
                 throw new GeneralException(ErrorStatus.TOKEN_INVALIDATE_ERROR);
             }


### PR DESCRIPTION
## 🔢 Issue Number
#17 

## 🎯 기능 개요
- 목적: 할 일 완료 상태 관리 기능 추가로 사용자 작업 흐름 개선
- 예시: 사용자가 할 일을 완료하면 PATCH 요청으로 상태를 완료(true)로 변경

## 🏗 구현 상세 및 설계 문서
- 경로: PATCH /api/v1/task/{taskId}/complete
- 요청: 경로 변수 taskId만 필요 (바디 없음)
- 응답: TaskResponse (완료 처리된 할 일 정보)
- 멱등성 보장: 이미 완료된 경우 중복 처리 없이 현재 상태 반환 
- status를 true로 변경 후 응답


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 작업을 완료로 표시하는 엔드포인트가 추가되었습니다.
  * 작업 및 컬렉션 응답에 썸네일 URL이 포함됩니다.

* **버그 픽스 / 개선**
  * 컬렉션별 작업 목록이 페이지네이션(무한 스크롤) 방식으로 변경되었고, 완료 여부(completed) 필터를 지원합니다.
  * 검색 결과의 컬렉션·작업이 페이지 단위로 반환되며, 추가 결과 존재 여부를 나타내는 hasMore 플래그가 제공됩니다.
  * 로그아웃 시 리프레시 토큰이 서버에서 제거되도록 개선되었습니다.

* **제거**
  * 기존 검색 미리보기 엔드포인트가 비활성화(제거)되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->