### PR TITLE
feat: API 명세서에 맞춰서 할 일 관련 기능 구현

### DIFF
--- a/src/main/java/com/doLink_server/domain/task/controller/TaskController.java
+++ b/src/main/java/com/doLink_server/domain/task/controller/TaskController.java
@@ -45,6 +45,29 @@ public class TaskController {
     }
 
     /**
+     * 전체 할 일 조회 (페이징, 무한 스크롤)
+     */
+    @GetMapping
+    @Operation(summary = "전체 할 일 조회", description = "로그인한 사용자의 모든 할 일을 최신순으로 페이징(무한 스크롤)하여 조회한다.")
+    public ApiResponse<Slice<TaskResponse>> listAll(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ApiResponse.onSuccess(taskService.listAll(page, size));
+    }
+
+    /**
+     * 최근 할 일 조회 (limit 개수 제한)
+     */
+    @GetMapping("/recent")
+    @Operation(summary = "최근 할 일 조회", description = "로그인한 사용자의 최근 할 일을 limit 개수만큼 조회한다.")
+    public ApiResponse<java.util.List<TaskResponse>> listRecent(
+            @RequestParam(defaultValue = "3") int limit
+    ) {
+        return ApiResponse.onSuccess(taskService.listRecent(limit));
+    }
+
+    /**
      * 할 일 단건 조회
      */
     @GetMapping("/{taskId}")
@@ -66,10 +89,10 @@ public class TaskController {
     }
 
     /**
-     * 할 일 완료 처리
+     * 할 일 상태 토글
      */
-    @PatchMapping("/{taskId}/complete")
-    @Operation(summary = "할 일 완료 처리", description = "할 일의 상태를 완료(true)로 변경한다.")
+    @PatchMapping("/{taskId}/toggle")
+    @Operation(summary = "할 일 상태 토글", description = "할 일의 상태를 토글한다. (완료 ↔ 미완료)")
     public ApiResponse<TaskResponse> completeTask(@PathVariable Long taskId) {
         return ApiResponse.onSuccess(taskService.completeTask(taskId));
     }

--- a/src/main/java/com/doLink_server/domain/task/dto/TaskUpdateRequest.java
+++ b/src/main/java/com/doLink_server/domain/task/dto/TaskUpdateRequest.java
@@ -1,9 +1,8 @@
 package com.doLink_server.domain.task.dto;
 
 public record TaskUpdateRequest(
+        Long collectionId, // 모음 ID
         String title,
         String link,
-        String memo,
-        Boolean status, // 완료 여부
-        Boolean inout   // 내부/외부 여부
+        String memo
 ) {}

--- a/src/main/java/com/doLink_server/domain/task/entity/Task.java
+++ b/src/main/java/com/doLink_server/domain/task/entity/Task.java
@@ -98,18 +98,12 @@ public class Task extends BaseEntity {
      * 기본 정보 수정 메서드
      * - 값이 null이 아닐 때만 변경 (PATCH 방식)
      */
-    public void updateElements(String title, String memo, Boolean status, Boolean inout) {
+    public void updateElements(String title, String memo) {
         if (title != null && !title.isBlank()) {
             this.title = title;
         }
         if (memo != null) {
             this.memo = memo;
-        }
-        if (status != null) {
-            this.status = status;
-        }
-        if (inout != null) {
-            this.inout = inout;
         }
     }
 
@@ -121,5 +115,14 @@ public class Task extends BaseEntity {
         this.link = link;
         this.ogImageKey = ogImageKey;
         this.thumbnailKey = thumbnailKey;
+    }
+
+    /**
+     * 완료 상태 토글 메서드
+     * - 완료(true) -> 미완료(false)
+     * - 미완료(false) -> 완료(true)
+     */
+    public void toggleStatus() {
+        this.status = !Boolean.TRUE.equals(this.status);
     }
 }

--- a/src/main/java/com/doLink_server/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/doLink_server/domain/task/repository/TaskRepository.java
@@ -1,8 +1,10 @@
 package com.doLink_server.domain.task.repository;
 
+import aj.org.objectweb.asm.commons.Remapper;
 import com.doLink_server.domain.task.entity.Task;
 
 import com.doLink_server.user.entity.Users;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -74,4 +76,23 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
      * [검색용] 사용자별 할 일 제목 포함 검색 (페이징)
      */
     Slice<Task> findByUserAndTitleContaining(Users user, String keyword, Pageable pageable);
+
+    /**
+     * 사용자별 전체 할 일 조회 (페이징, 무한 스크롤)
+     */
+    Slice<Task> findAllByUser(Users user, Pageable pageable);
+
+    /**
+     * 사용자별 전체 할 일 조회 (페이징, 무한 스크롤) + 완료/미완료 필터
+     *
+     * @param status true: 완료, false: 미완료
+     */
+    Slice<Task> findAllByUserAndStatus(Users user, Boolean status, Pageable pageable);
+
+    /**
+     * 사용자별 최근 할 일 조회 (limit 개수 제한)
+     * - 최신순으로 limit 개수만큼 조회
+     */
+    @Query("SELECT t FROM Task t JOIN FETCH t.collection c WHERE t.user = :user ORDER BY t.createdAt DESC")
+    List<Task> findRecentTasksByUser(@Param("user") Users user, Pageable pageable);
 }

--- a/src/main/java/com/doLink_server/domain/task/service/TaskService.java
+++ b/src/main/java/com/doLink_server/domain/task/service/TaskService.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -131,11 +132,33 @@ public class TaskService {
     }
 
     /**
-     * 모음별 Task 전체 조회 (페이징)
-     * - 하위 호환용 오버로드 (필터 없음)
+     * 사용자별 전체 할 일 조회 (페이징)
+     * - 모든 모음의 할 일을 최신순으로 조회
      */
-    public Slice<TaskResponse> listByCollection(Long collectionId, int page, int size, String sort) {
-        return listByCollection(collectionId, page, size, sort, null);
+    public Slice<TaskResponse> listAll(int page, int size) {
+        String currentUserId = authService.getAuthenticatedUserId();
+        Users user = userService.findExistingUser(currentUserId);
+
+        PageRequest pageable = PageRequest.of(page, size);
+
+        return taskRepository.findAllByUser(user, pageable)
+                .map(this::toResponse);
+    }
+
+    /**
+     * 사용자별 최근 할 일 조회 (limit 개수 제한)
+     * - 최신순으로 limit 개수만큼 조회
+     */
+    public List<TaskResponse> listRecent(int limit) {
+        String currentUserId = authService.getAuthenticatedUserId();
+        Users user = userService.findExistingUser(currentUserId);
+
+        PageRequest pageable = PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        return taskRepository.findRecentTasksByUser(user, pageable)
+                .stream()
+                .map(this::toResponse)
+                .toList();
     }
 
     /**
@@ -154,7 +177,20 @@ public class TaskService {
             throw new GeneralException(ErrorStatus._UNAUTHORIZED_TASK);
         }
 
-        task.updateElements(request.title(), request.memo(), request.status(), request.inout());
+        // 모음 변경 로직
+        if (request.collectionId() != null && !request.collectionId().equals(task.getCollection().getCollectionId())) {
+            Collection newCollection = collectionRepository.findByIdWithUser(request.collectionId())
+                    .orElseThrow(() -> new GeneralException(ErrorStatus._NOT_FOUND_COLLECTION));
+
+            // 새로운 모음도 내 모음인지 확인
+            if (!Arrays.equals(newCollection.getUser().getUserId(), user.getUserId())) {
+                throw new GeneralException(ErrorStatus._UNAUTHORIZED_TASK);
+            }
+
+            task.setCollection(newCollection);
+        }
+
+        task.updateElements(request.title(), request.memo());
 
         // 링크 수정 로직
         if (request.link() != null) {
@@ -174,7 +210,9 @@ public class TaskService {
     }
 
     /**
-     * 할 일 완료 처리
+     * 할 일 완료 상태 토글
+     * - 완료(true) -> 미완료(false)
+     * - 미완료(false) -> 완료(true)
      */
     @Transactional
     public TaskResponse completeTask(Long taskId) {
@@ -189,12 +227,8 @@ public class TaskService {
             throw new GeneralException(ErrorStatus._UNAUTHORIZED_TASK);
         }
 
-        // 이미 완료인 경우 그냥 현재 상태 반환
-        if (Boolean.TRUE.equals(task.getStatus())) {
-            return toResponse(task);
-        }
-
-        task.setStatus(true);
+        // 상태 토글
+        task.toggleStatus();
 
         return toResponse(task);
     }


### PR DESCRIPTION
## 🔢 Issue Number
- #21 

## 🎯 기능 개요
- **목적**: Task 엔티티의 상태 관리 개선 및 최근 할 일 조회 API 추가
- **주요 기능**:
  1. Task 완료 상태 토글 기능 리팩토링 (도메인 로직 캡슐화)
  2. 최근 할 일 조회 API 구현 (limit 파라미터 지원)

## 🏗 구현 상세 및 설계 문서

### 1. Task 완료 상태 토글 기능 리팩토링
**변경 파일**: `Task.java`
```java
// Task 엔티티에 toggleStatus() 메서드 추가
public void toggleStatus() {
    this.status = !Boolean.TRUE.equals(this.status);
}
```

**설계 의도**:
- 비즈니스 로직을 엔티티 내부로 캡슐화하여 객체지향 설계 원칙 준수
- Service Layer에서 직접 setter를 호출하는 대신 도메인 메서드 사용
- 상태 토글 로직의 재사용성 및 유지보수성 향상

### 2. 최근 할 일 조회 API
**엔드포인트**: `GET /api/v1/task/recent`

**구현 계층**:

#### Controller Layer
```java
@GetMapping("/recent")
public ApiResponse<List<TaskResponse>> listRecent(
    @RequestParam(defaultValue = "3") int limit
)
```

#### Service Layer
```java
public List<TaskResponse> listRecent(int limit) {
    // 인증된 사용자의 최근 할일을 limit 개수만큼 조회
    PageRequest pageable = PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "createdAt"));
    return taskRepository.findRecentTasksByUser(user, pageable)
        .stream()
        .map(this::toResponse)
        .toList();
}
```

#### Repository Layer
```java
@Query("SELECT t FROM Task t JOIN FETCH t.collection c WHERE t.user = :user ORDER BY t.createdAt DESC")
List<Task> findRecentTasksByUser(@Param("user") Users user, Pageable pageable);
```

**설계 특징**:
- N+1 문제 방지를 위한 Collection fetch join
- 쿼리 파라미터로 limit 개수 조정 가능 (기본값: 3)
- 최신순 정렬 (createdAt DESC)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 모든 작업을 페이지 단위로 조회할 수 있는 기능 추가
  * 최신 작업들을 빠르게 조회할 수 있는 기능 추가
  * 작업 상태를 완료/미완료로 토글할 수 있도록 개선
  * 작업을 다른 컬렉션으로 이동할 수 있는 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->