### PR TITLE
feat: 링크 유효성 검증(linkValid) 필드 추가

### DIFF
--- a/src/main/java/com/doLink_server/domain/task/dto/LinkCreateResult.java
+++ b/src/main/java/com/doLink_server/domain/task/dto/LinkCreateResult.java
@@ -12,7 +12,8 @@ public record LinkCreateResult(
         String originalKey,
         String originalUrl,
         String thumbnailKey,
-        String thumbnailUrl
+        String thumbnailUrl,
+        boolean linkValid
 ) {
 
 }

--- a/src/main/java/com/doLink_server/domain/task/dto/TaskResponse.java
+++ b/src/main/java/com/doLink_server/domain/task/dto/TaskResponse.java
@@ -12,6 +12,7 @@ public class TaskResponse {
     private Long collectionId;
     private String title;
     private String link;
+    private Boolean linkValid;
     private String memo;
     private String domain;
     private String thumbnailUrl;

--- a/src/main/java/com/doLink_server/domain/task/entity/Task.java
+++ b/src/main/java/com/doLink_server/domain/task/entity/Task.java
@@ -61,6 +61,12 @@ public class Task extends BaseEntity {
     private String link;
 
     /**
+     * 링크 유효성 여부 (접속 가능 여부)
+     */
+    @Column(name = "link_valid")
+    private Boolean linkValid;
+
+    /**
      * OG 대표 썸네일 S3 key
      * - DB에는 URL이 아니라 key만 저장 (presigned는 조회 시 생성)
      */
@@ -126,10 +132,11 @@ public class Task extends BaseEntity {
      * 링크 및 OG 데이터 수정 메서드
      * - 링크 관련 정보는 세트로 움직이므로 별도 메서드로 분리
      */
-    public void updateLink(String link, String ogImageKey, String thumbnailKey) {
+    public void updateLink(String link, String ogImageKey, String thumbnailKey, Boolean linkValid) {
         this.link = link;
         this.ogImageKey = ogImageKey;
         this.thumbnailKey = thumbnailKey;
+        this.linkValid = linkValid;
     }
 
     /**

--- a/src/main/java/com/doLink_server/domain/task/service/LinkCreateService.java
+++ b/src/main/java/com/doLink_server/domain/task/service/LinkCreateService.java
@@ -72,7 +72,8 @@ public class LinkCreateService {
                     originalKey,
                     originalUrl,
                     thumbnailKey,
-                    thumbnailUrl
+                    thumbnailUrl,
+                    og.linkValid()
             );
 
         } catch (Exception e) {

--- a/src/main/java/com/doLink_server/domain/task/service/TaskService.java
+++ b/src/main/java/com/doLink_server/domain/task/service/TaskService.java
@@ -62,12 +62,14 @@ public class TaskService {
         String finalTitle = request.title(); // 사용자가 직접 입력한 제목
         String ogImageKey = null;
         String thumbnailKey = null;
+        Boolean linkValid = null;
 
         if (request.link() != null && !request.link().isBlank()) {
             LinkCreateResult linkResult = linkCreateService.create(request.link());
 
             ogImageKey = linkResult.originalKey();
             thumbnailKey = linkResult.thumbnailKey();
+            linkValid = linkResult.linkValid();
 
             // 사용자가 제목을 입력하지 않았다면 OG 제목을 정제해서 사용
             if (finalTitle == null || finalTitle.isBlank()) {
@@ -85,6 +87,7 @@ public class TaskService {
                         .memo(request.memo())
                         .ogImageKey(ogImageKey)
                         .thumbnailKey(thumbnailKey)
+                        .linkValid(linkValid)
                         .inout(request.inout())
                         .status(false)
                         .isTutorial(false)
@@ -231,11 +234,11 @@ public class TaskService {
 
             if (newLink.isBlank()) {
                 // 링크 삭제
-                task.updateLink(null, null, null);
+                task.updateLink(null, null, null, null);
             } else if (!newLink.equals(task.getLink())) {
                 // 링크 변경 (새로 파싱)
                 LinkCreateResult linkResult = linkCreateService.create(newLink);
-                task.updateLink(newLink, linkResult.originalKey(), linkResult.thumbnailKey());
+                task.updateLink(newLink, linkResult.originalKey(), linkResult.thumbnailKey(), linkResult.linkValid());
             }
         }
 
@@ -302,6 +305,7 @@ public class TaskService {
                 .collectionId(t.getCollection().getCollectionId())
                 .title(t.getTitle())
                 .link(t.getLink())
+                .linkValid(t.getLinkValid())
                 .memo(t.getMemo())
                 .domain(domain)
                 .thumbnailUrl(thumbnailUrl)

--- a/src/main/java/com/doLink_server/infra/og/dto/OgMetadata.java
+++ b/src/main/java/com/doLink_server/infra/og/dto/OgMetadata.java
@@ -9,6 +9,10 @@ public record OgMetadata(
         String description,
         String imageUrl,      // 원본 og:image (외부 URL)
         String siteName,
-        String canonicalUrl   // og:url 또는 canonical
+        String canonicalUrl,  // og:url 또는 canonical
+        boolean linkValid     // URL 접속 성공 여부
 ) {
+    public static OgMetadata invalid() {
+        return new OgMetadata(null, null, null, null, null, false);
+    }
 }

--- a/src/main/java/com/doLink_server/infra/og/parser/OgMetadataParser.java
+++ b/src/main/java/com/doLink_server/infra/og/parser/OgMetadataParser.java
@@ -25,12 +25,18 @@ public class OgMetadataParser {
      */
     public OgMetadata parse(String url) {
         try {
-            Document doc = Jsoup.connect(url)
+            org.jsoup.Connection.Response response = Jsoup.connect(url)
                     .userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
                     .timeout(TIMEOUT_MS)
                     .followRedirects(true)
                     .ignoreHttpErrors(true)
-                    .get();
+                    .execute();
+
+            if (response.statusCode() >= 400) {
+                return OgMetadata.invalid();
+            }
+
+            Document doc = response.parse();
 
             // OG 메타데이터 우선 추출
             String ogTitle = meta(doc, "property", "og:title");
@@ -56,12 +62,12 @@ public class OgMetadataParser {
                     trimToNull(ogDesc),
                     trimToNull(ogImage),
                     trimToNull(ogSite),
-                    trimToNull(finalUrl)
+                    trimToNull(finalUrl),
+                    true
             );
 
         } catch (Exception e) {
-            // 파싱 실패 시에도 링크 저장 로직을 유지하기 위해 null 기반 결과 반환
-            return new OgMetadata(null, null, null, null, null);
+            return OgMetadata.invalid();
         }
     }
 


### PR DESCRIPTION
- Task 엔티티에 link_valid 컬럼 추가
- OgMetadataParser에서 HTTP 상태코드 400 이상 시 invalid 처리
- 생성/수정 시 링크 접속 가능 여부를 저장하여 응답에 포함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * HTTP 상태 코드 검사를 통해 무효한 링크를 감지하고 처리합니다.

* **개선 사항**
  * 링크 유효성 정보가 시스템에서 추적되고 API 응답에 포함됩니다.
  * 링크 생성 및 업데이트 시 유효성 상태가 함께 저장됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->