### PR TITLE
feat(auth): Google 네이티브 로그인 ID 토큰 검증 및 JWT 발급

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,11 @@ java {
 	}
 }
 
+// @RequestParam / @PathVariable 의 파라미터 이름을 리플렉션으로 사용 (이름 미지정 시 필수)
+tasks.withType(JavaCompile).configureEach {
+	options.compilerArgs.add("-parameters")
+}
+
 configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
@@ -50,6 +55,9 @@ dependencies {
 	// JPA
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
+
+	// Google ID 토큰 검증 (Android/iOS 네이티브 로그인)
+	implementation 'com.google.api-client:google-api-client:2.7.2'
 
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/src/main/java/com/doLink_server/auth/controller/AuthController.java
+++ b/src/main/java/com/doLink_server/auth/controller/AuthController.java
@@ -1,5 +1,9 @@
 package com.doLink_server.auth.controller;
 
+import com.doLink_server.auth.dto.GoogleNativeLoginRequest;
+import com.doLink_server.auth.dto.GoogleNativeTokenResult;
+import com.doLink_server.auth.service.AuthRefreshCookieWriter;
+import com.doLink_server.auth.service.GoogleNativeAuthService;
 import com.doLink_server.auth.service.JwtIssueService;
 import com.doLink_server.auth.service.RedisService;
 import com.doLink_server.global.common.ApiResponse;
@@ -11,10 +15,13 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,6 +38,24 @@ public class AuthController {
     private final JwtProvider jwtProvider;
     private final JwtIssueService jwtIssueService;
     private final RedisService redisService;
+    private final GoogleNativeAuthService googleNativeAuthService;
+    private final AuthRefreshCookieWriter authRefreshCookieWriter;
+
+    /**
+     * Android/iOS 네이티브 Google Sign-In: ID 토큰 검증 후 JWT 발급
+     */
+    @PostMapping("/oauth/google/native")
+    @Operation(summary = "Google 네이티브 로그인", description = "Google ID 토큰을 검증하고 access·refresh JWT를 발급합니다.")
+    public ResponseEntity<ApiResponse<GoogleNativeTokenResult>> googleNativeLogin(
+            @Valid @RequestBody GoogleNativeLoginRequest request,
+            HttpServletResponse httpResponse
+    ) {
+        GoogleNativeTokenResult result = googleNativeAuthService.loginWithIdToken(request.idToken());
+        authRefreshCookieWriter.addRefreshTokenCookie(httpResponse, result.refreshToken());
+        return ResponseEntity.ok()
+                .header("Authorization", "Bearer " + result.accessToken())
+                .body(ApiResponse.onSuccess(result));
+    }
 
     /**
      * AccessToken 재발급

--- a/src/main/java/com/doLink_server/auth/dto/GoogleNativeLoginRequest.java
+++ b/src/main/java/com/doLink_server/auth/dto/GoogleNativeLoginRequest.java
@@ -1,0 +1,9 @@
+package com.doLink_server.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 앱 네이티브 Google Sign-In 후 서버로 전달하는 요청
+ */
+public record GoogleNativeLoginRequest(@NotBlank String idToken) {
+}

--- a/src/main/java/com/doLink_server/auth/dto/GoogleNativeTokenResult.java
+++ b/src/main/java/com/doLink_server/auth/dto/GoogleNativeTokenResult.java
@@ -1,0 +1,7 @@
+package com.doLink_server.auth.dto;
+
+/**
+ * 네이티브 Google 로그인 성공 시 앱(WebView)으로 내려주는 토큰 쌍
+ */
+public record GoogleNativeTokenResult(String accessToken, String refreshToken) {
+}

--- a/src/main/java/com/doLink_server/auth/oauth/handler/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/doLink_server/auth/oauth/handler/CustomOAuth2SuccessHandler.java
@@ -1,19 +1,16 @@
 package com.doLink_server.auth.oauth.handler;
 
 
+import com.doLink_server.auth.service.AuthRefreshCookieWriter;
 import com.doLink_server.auth.service.JwtIssueService;
 import com.doLink_server.auth.service.RedisService;
 import com.doLink_server.global.util.UUIDToBytesUtil;
-import com.doLink_server.security.jwt.JwtProperties;
-import com.doLink_server.security.jwt.JwtProvider;
 import com.doLink_server.user.entity.Users;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.env.Environment;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -30,17 +27,12 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    private final JwtProvider jwtProvider;
     private final RedisService redisService;
-    private final JwtProperties jwtProperties;
     private final JwtIssueService jwtIssueService;
-    private final Environment environment;
+    private final AuthRefreshCookieWriter authRefreshCookieWriter;
 
     @Value("${auth.redirect.url}")
     private String redirectUrl;
-
-    @Value("${auth.cookie.domain}")
-    private String cookieDomain;
 
     /**
      * 인증 성공시, 리프레시 토큰을 Http Only 쿠키로 반환한다.
@@ -83,7 +75,7 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
 
         // 5. HttpOnly, Secure 옵션 적용한 쿠키에 refreshToken 세팅
         // accessToken은 쿠키에 담지 않고, 필요하다면 이후 API 요청으로 전달받도록 구성
-        addRefreshTokenCookie(response, finalRefreshToken);
+        authRefreshCookieWriter.addRefreshTokenCookie(response, finalRefreshToken);
 
 //        String accessToken = tokenService.issueAccessToken(userId);
 //        response.setHeader("Authorization", "Bearer " + accessToken);
@@ -127,44 +119,6 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
     }
 
     /**
-     * 요청 쿠키에서 refreshToken 값을 추출한다.
-     * @param request HttpServletRequest
-     * @return 쿠키에 "refresh" 이름으로 저장된 토큰 값, 없으면 null 반환
-     */
-    private String extractRefreshTokenFromCookie(HttpServletRequest request) {
-        if (request.getCookies() == null) return null;
-
-        for (Cookie cookie : request.getCookies()) {
-            if ("refresh".equals(cookie.getName())) {
-                return cookie.getValue();
-            }
-        }
-        return null;
-    }
-
-    /**
-     * HttpOnly, Secure 옵션이 적용된 리프레시 토큰 쿠키를 생성하고 응답에 추가
-     */
-    private void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
-        Cookie cookie = new Cookie("refresh", refreshToken);
-        cookie.setHttpOnly(true);  // 자바스크립트에서 접근 불가
-        cookie.setSecure(isSecure());  // 환경에 따라 true/false
-        cookie.setPath("/");       // 모든 경로에 대해 유효
-        cookie.setDomain(cookieDomain); // 루트 도메인
-        cookie.setMaxAge((int) (jwtProperties.getRefreshTokenExpiration() / 1000));  // 초 단위 만료시간
-        response.addCookie(cookie);
-    }
-
-    private boolean isSecure() {
-        for (String profile : environment.getActiveProfiles()) {
-            if ("prod".equals(profile)) {
-                return true;
-            }
-        }
-        return false; // local, dev 등의 경우
-    }
-
-    /**
      * 오류 로그를 기록하고 401 Unauthorized 응답 전송
      */
     private void logAndSendError(HttpServletResponse response, String message) throws IOException {
@@ -173,14 +127,4 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
         response.sendError(HttpServletResponse.SC_UNAUTHORIZED, message);
     }
 
-    /**
-     * JWT 토큰의 Claims(payload)를 JSON 형식으로 예쁘게 로그에 출력한다.
-     * 디버깅용으로 Redis와 클라이언트 토큰 비교 시 호출하면 유용하다.
-     */
-    private void logTokenDetails(String label, String token) {
-        jwtProvider.extractClaimsAsJson(token).ifPresentOrElse(
-                json -> log.info(">>> JWT Claims [{}]:\n{}", label, json),
-                () -> log.warn("JWT Claims [{}]: 유효하지 않아 파싱 실패", label)
-        );
-    }
 }

--- a/src/main/java/com/doLink_server/auth/service/AuthRefreshCookieWriter.java
+++ b/src/main/java/com/doLink_server/auth/service/AuthRefreshCookieWriter.java
@@ -1,0 +1,42 @@
+package com.doLink_server.auth.service;
+
+import com.doLink_server.security.jwt.JwtProperties;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+/**
+ * OAuth 웹 로그인 / 네이티브 로그인 공통: refresh 토큰 HttpOnly 쿠키 설정
+ */
+@Component
+@RequiredArgsConstructor
+public class AuthRefreshCookieWriter {
+
+    private final JwtProperties jwtProperties;
+    private final Environment environment;
+
+    @Value("${auth.cookie.domain}")
+    private String cookieDomain;
+
+    public void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        Cookie cookie = new Cookie("refresh", refreshToken);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(isSecure());
+        cookie.setPath("/");
+        cookie.setDomain(cookieDomain);
+        cookie.setMaxAge((int) (jwtProperties.getRefreshTokenExpiration() / 1000));
+        response.addCookie(cookie);
+    }
+
+    private boolean isSecure() {
+        for (String profile : environment.getActiveProfiles()) {
+            if ("prod".equals(profile)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/doLink_server/auth/service/GoogleNativeAuthService.java
+++ b/src/main/java/com/doLink_server/auth/service/GoogleNativeAuthService.java
@@ -1,0 +1,94 @@
+package com.doLink_server.auth.service;
+
+import com.doLink_server.auth.dto.GoogleNativeTokenResult;
+import com.doLink_server.auth.oauth.model.GoogleUserInfo;
+import com.doLink_server.auth.oauth.model.OAuth2UserInfo;
+import com.doLink_server.global.common.status.ErrorStatus;
+import com.doLink_server.global.exception.GeneralException;
+import com.doLink_server.global.util.UUIDToBytesUtil;
+import com.doLink_server.user.entity.Users;
+import com.doLink_server.user.service.UserService;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Google ID 토큰 기반 네이티브 로그인 (React Native Google Sign-In)
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GoogleNativeAuthService {
+
+    @Value("${spring.security.oauth2.client.registration.google.client-id}")
+    private String googleWebClientId;
+
+    private final UserService userService;
+    private final JwtIssueService jwtIssueService;
+    private final RedisService redisService;
+
+    public GoogleNativeTokenResult loginWithIdToken(String rawIdToken) {
+        GoogleIdToken idToken = verifyGoogleIdToken(rawIdToken);
+        GoogleIdToken.Payload payload = idToken.getPayload();
+
+        if (payload.getSubject() == null || payload.getSubject().isBlank()) {
+            throw new GeneralException(ErrorStatus._INVALID_GOOGLE_ID_TOKEN);
+        }
+
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("sub", payload.getSubject());
+        attributes.put("email", payload.getEmail());
+        attributes.put("name", payload.get("name"));
+        attributes.put("picture", payload.get("picture"));
+        OAuth2UserInfo userInfo = new GoogleUserInfo(attributes);
+
+        Users user = resolveOrRegisterUser(userInfo);
+
+        String userId = UUIDToBytesUtil.convertToEntityAttribute(user.getUserId()).toString();
+        String refreshToken = jwtIssueService.issueRefreshToken(userId);
+        redisService.saveRefreshToken(userId, refreshToken);
+        String accessToken = jwtIssueService.issueAccessToken(userId);
+
+        return new GoogleNativeTokenResult(accessToken, refreshToken);
+    }
+
+    private Users resolveOrRegisterUser(OAuth2UserInfo userInfo) {
+        try {
+            return userService.findExistingUser(userInfo);
+        } catch (GeneralException e) {
+            if (e.getCode() == ErrorStatus._NOT_FOUND_USER) {
+                return userService.join(userInfo);
+            }
+            throw e;
+        }
+    }
+
+    private GoogleIdToken verifyGoogleIdToken(String idTokenString) {
+        try {
+            GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier.Builder(
+                    new NetHttpTransport(),
+                    GsonFactory.getDefaultInstance())
+                    .setAudience(Collections.singletonList(googleWebClientId))
+                    .build();
+            GoogleIdToken token = verifier.verify(idTokenString);
+            if (token == null) {
+                throw new GeneralException(ErrorStatus._INVALID_GOOGLE_ID_TOKEN);
+            }
+            return token;
+        } catch (GeneralException e) {
+            throw e;
+        } catch (Exception e) {
+            log.warn("Google ID token verification failed: {}", e.getMessage());
+            throw new GeneralException(ErrorStatus._INVALID_GOOGLE_ID_TOKEN);
+        }
+    }
+}

--- a/src/main/java/com/doLink_server/global/common/status/ErrorStatus.java
+++ b/src/main/java/com/doLink_server/global/common/status/ErrorStatus.java
@@ -29,6 +29,9 @@ public enum ErrorStatus implements BaseErrorCode {
     _FILE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FILE503", "파일삭제에 실패하였습니다."),
     _WITHDRAW_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "USER500", "사용자 삭제에 실패하였습니다."),
 
+    // Google 네이티브 로그인 (ID 토큰)
+    _INVALID_GOOGLE_ID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4003", "유효하지 않은 Google ID 토큰입니다."),
+
     // Social 인증 해제 에러
     _UNSUPPORTED_SOCIAL_PLATFORM(HttpStatus.BAD_REQUEST, "SOCIAL400", "지원하지 않는 소셜 플랫폼입니다."),
     _NOT_IMPLEMENTED_SOCIAL(HttpStatus.NOT_IMPLEMENTED, "SOCIAL501", "해당 소셜 플랫폼의 해제 기능은 아직 구현되지 않았습니다."),

--- a/src/main/java/com/doLink_server/security/config/SecurityConfig.java
+++ b/src/main/java/com/doLink_server/security/config/SecurityConfig.java
@@ -107,6 +107,7 @@ public class SecurityConfig {
      */
     private static final String[] WHITE_LIST_URL = {
             "/v1/auth/reissue",
+            "/v1/auth/oauth/google/native",
 
             // swagger
             "/v3/api-docs/**",


### PR DESCRIPTION
- POST /v1/auth/oauth/google/native 엔드포인트 추가
- GoogleIdTokenVerifier로 audience 검증 후 회원 조회·가입 및 토큰 발급
- refresh 토큰 HttpOnly 쿠키는 AuthRefreshCookieWriter로 공통 처리
- OAuth2 성공 핸들러를 동일 쿠키 라이터로 정리

Made-with: Cursor

## 🔢 Issue Number
- 이슈번호(#으로 이슈 태깅)

## 🎯 기능 개요
- **목적**: 사용자 경험 향상을 위한 새로운 대시보드 기능 추가.
- **예시**: 대시보드에 실시간 트래픽 데이터 표시 기능 구현.

## 🏗 구현 상세 및 설계 문서
- 사용자 인터페이스 업데이트
- 백엔드 로직 통합
- [대시보드 기능 설계 문서 링크](#)

## 🧪 테스트 계획 및 결과
- 자동화 테스트 케이스(간단하게) 추가 및 실행 결과

## 🔍 사이드 이펙트 분석
- 변경 사항이 기존 기능에 미칠 영향 검토

## ✅ 체크리스트
- [ ] 기능별 코드 리뷰 완료
- [ ] 테스트 커버리지 80% 이상(보류)

## 📝 추가 노트
- 추가 개선 사항에 대한 토론 필요

## 💌 To Reviewers
- 주의사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 네이티브 Google 인증 지원 추가 - Google ID 토큰으로 로그인 가능
  * 새로고침 토큰 자동 쿠키 설정 - HttpOnly 보안 쿠키로 저장

* **리팩토링**
  * 새로고침 토큰 쿠키 처리 로직을 독립 컴포넌트로 분리하여 재사용성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->